### PR TITLE
Fix invalid Github label in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,8 +27,7 @@ github:
     - streaming
     - queuing
     - event-streaming
-    - .NET
-    - C#
+    - dotnet
   features:
     # Enable wiki for documentation
     wiki: true


### PR DESCRIPTION
*Motivation*

Fix error `Invalid GitHub label '.NET' - must be lowercase alphanumerical and <= 35 characters!`