### PR TITLE
Add Proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For a more in-depth tour of the API, please visit the [Wiki](https://github.com/
 - [X] Consume compacted topics
 - [X] Reader API
 - [X] Read/Consume/Acknowledge batched messages
+- [X] Pulsar Proxy
 
 ## Roadmap
 


### PR DESCRIPTION
This adds support for connection through a pulsar proxy. Tested against Kafkaeseque's SAAS offering.

This closes [Issue 36](https://github.com/apache/pulsar-dotpulsar/issues/36)