### PR TITLE
Fix checking MessageId against null throwing NRE

### DIFF
--- a/src/DotPulsar/MessageId.cs
+++ b/src/DotPulsar/MessageId.cs
@@ -76,13 +76,13 @@ namespace DotPulsar
             => o is MessageId id && Equals(id);
 
         public bool Equals(MessageId other)
-            => LedgerId == other.LedgerId && EntryId == other.EntryId && Partition == other.Partition && BatchIndex == other.BatchIndex;
+            => !(other is null) && LedgerId == other.LedgerId && EntryId == other.EntryId && Partition == other.Partition && BatchIndex == other.BatchIndex;
 
         public static bool operator ==(MessageId x, MessageId y)
-            => x.Equals(y);
+            => object.ReferenceEquals(x, y) || (!object.ReferenceEquals(x, null) && x.Equals(y));
 
         public static bool operator !=(MessageId x, MessageId y)
-            => !x.Equals(y);
+            => !(x == y);
 
         public override int GetHashCode()
             => HashCode.Combine(LedgerId, EntryId, Partition, BatchIndex);

--- a/tests/DotPulsar.Tests/MessageIdTests.cs
+++ b/tests/DotPulsar.Tests/MessageIdTests.cs
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// We cannot assume consumers of this library will obey the nullability guarantees
+#nullable disable
+
+namespace DotPulsar.Tests
+{
+    using DotPulsar;
+    using Xunit;
+
+    public class MessageIdTests
+    {
+        [Fact]
+        public void MessageId_Equality_SameReference()
+        {
+            var m1 = new MessageId(1234, 5678, 9876, 5432);
+            var m2 = m1;
+            Assert.True(m1.Equals(m2));
+            Assert.True(m1 == m2);
+            Assert.False(m1 != m2);
+        }
+
+        [Fact]
+        public void MessageId_Equality_SameValues()
+        {
+            var m1 = new MessageId(1234, 5678, 9876, 5432);
+            var m2 = new MessageId(1234, 5678, 9876, 5432);
+            Assert.True(m1.Equals(m2));
+            Assert.True(m1 == m2);
+            Assert.False(m1 != m2);
+        }
+
+        [Fact]
+        public void MessageId_Inequality_DifferentValues()
+        {
+            var m1 = new MessageId(1234, 5678, 9876, 5432);
+            var m2 = new MessageId(9876, 6432, 1234, 6678);
+            Assert.False(m1.Equals(m2));
+            Assert.False(m1 == m2);
+            Assert.True(m1 != m2);
+        }
+
+        [Fact]
+        public void MessageId_Equality_Null()
+        {
+            MessageId m1 = null;
+            MessageId m2 = null;
+            Assert.True(m1 == m2);
+            Assert.True(m1 == null);
+            Assert.False(m1 != m2);
+        }
+
+        [Fact]
+        public void MessageId_Inequality_NotNull()
+        {
+            var m1 = new MessageId(1234, 5678, 9876, 5432);
+            MessageId m2 = null;
+            Assert.False(m1 == null);
+            Assert.False(m1 == m2);
+            Assert.False(m1.Equals(m2));
+            Assert.True(m1 != m2);
+        }
+    }
+}


### PR DESCRIPTION
In a confusingly ironic twist, using the new nullable language features in a public-facing area of this library has caused a bug where if a consumer checks a `MessageId` against `null` it will throw a NullReferenceException, which is pretty much the worst thing it could do in that scenario.  Since we target .net standard 2.0 and no particular language version as a library, we should be tolerant of such a check, even if it is not possible for that value to be null.