### PR TITLE
Eat errors in SetupChannel

### DIFF
--- a/src/DotPulsar/Internal/ConsumerProcess.cs
+++ b/src/DotPulsar/Internal/ConsumerProcess.cs
@@ -89,9 +89,9 @@ namespace DotPulsar.Internal
                 var channel = await _factory.Create(CancellationTokenSource.Token).ConfigureAwait(false);
                 await _consumer.SetChannel(channel).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch
             {
-                Console.WriteLine($"Setup Channel failed for Consumer \n {ex.ToString()}");
+                // ignored
             }
         }
     }

--- a/src/DotPulsar/Internal/ConsumerProcess.cs
+++ b/src/DotPulsar/Internal/ConsumerProcess.cs
@@ -84,8 +84,15 @@ namespace DotPulsar.Internal
 
         private async void SetupChannel()
         {
-            var channel = await _factory.Create(CancellationTokenSource.Token).ConfigureAwait(false);
-            await _consumer.SetChannel(channel).ConfigureAwait(false);
+            try
+            {
+                var channel = await _factory.Create(CancellationTokenSource.Token).ConfigureAwait(false);
+                await _consumer.SetChannel(channel).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Setup Channel failed for Consumer \n {ex.ToString()}");
+            }
         }
     }
 }

--- a/src/DotPulsar/Internal/ProducerProcess.cs
+++ b/src/DotPulsar/Internal/ProducerProcess.cs
@@ -73,9 +73,9 @@ namespace DotPulsar.Internal
                 var channel = await _factory.Create(CancellationTokenSource.Token).ConfigureAwait(false);
                 await _producer.SetChannel(channel).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch
             {
-                Console.WriteLine($"Setup Channel failed for Producer \n {ex.ToString()}");
+                // ignored
             }
         }
     }

--- a/src/DotPulsar/Internal/ProducerProcess.cs
+++ b/src/DotPulsar/Internal/ProducerProcess.cs
@@ -68,8 +68,15 @@ namespace DotPulsar.Internal
 
         private async void SetupChannel()
         {
-            var channel = await _factory.Create(CancellationTokenSource.Token).ConfigureAwait(false);
-            await _producer.SetChannel(channel).ConfigureAwait(false);
+            try
+            {
+                var channel = await _factory.Create(CancellationTokenSource.Token).ConfigureAwait(false);
+                await _producer.SetChannel(channel).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Setup Channel failed for Producer \n {ex.ToString()}");
+            }
         }
     }
 }

--- a/src/DotPulsar/Internal/ReaderProcess.cs
+++ b/src/DotPulsar/Internal/ReaderProcess.cs
@@ -71,8 +71,15 @@ namespace DotPulsar.Internal
 
         private async void SetupChannel()
         {
-            var channel = await _factory.Create(CancellationTokenSource.Token).ConfigureAwait(false);
-            await _reader.SetChannel(channel).ConfigureAwait(false);
+            try
+            {
+                var channel = await _factory.Create(CancellationTokenSource.Token).ConfigureAwait(false);
+                await _reader.SetChannel(channel).ConfigureAwait(false);
+            }
+            catch
+            {
+                // ignored
+            }
         }
     }
 }


### PR DESCRIPTION
Errors thrown in an async void method cannot be caught, resulting in application crashes in some cases.