### PR TITLE
Add a watchdog to the connections

### DIFF
--- a/src/DotPulsar/Abstractions/IPulsarClientBuilder.cs
+++ b/src/DotPulsar/Abstractions/IPulsarClientBuilder.cs
@@ -53,6 +53,11 @@ namespace DotPulsar.Abstractions
         IPulsarClientBuilder RetryInterval(TimeSpan interval);
 
         /// <summary>
+        /// Set a timeout for the watchdog to reconnect if no messages are received. The default disabled (using Timeout.InfiniteTimespan).
+        /// </summary>
+        public IPulsarClientBuilder UseWatchdog(TimeSpan timeout);
+
+        /// <summary>
         /// The service URL for the Pulsar cluster. The default is "pulsar://localhost:6650".
         /// </summary>
         IPulsarClientBuilder ServiceUrl(Uri uri);

--- a/src/DotPulsar/Internal/Watchdog.cs
+++ b/src/DotPulsar/Internal/Watchdog.cs
@@ -1,0 +1,61 @@
+﻿namespace DotPulsar.Internal
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading;
+
+    public class Watchdog: IDisposable
+    {
+        private CancellationTokenSource _cancellationTokenSource;
+        private readonly TimeSpan _timeout;
+        private readonly Timer _timer;
+
+        public Watchdog(TimeSpan timeout)
+        {
+            _timeout = timeout;
+            _timer = new Timer(OnTimeout);
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        public CancellationToken CancellationToken
+        {
+            get => _cancellationTokenSource.Token;
+        }
+
+        public void GotMessage()
+        {
+            ResetTimer();
+        }
+
+        public void Enable()
+        {
+            if (_cancellationTokenSource.IsCancellationRequested)
+                _cancellationTokenSource = new CancellationTokenSource();
+            ResetTimer();
+        }
+
+        public void Disable()
+        {
+            _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+
+        private void ResetTimer()
+        {
+            _timer.Change(_timeout, Timeout.InfiniteTimeSpan);
+        }
+
+        private void OnTimeout(object state)
+        {
+            Console.WriteLine("Watchdog timeout");
+            Disable();
+            _cancellationTokenSource.Cancel();
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+            _cancellationTokenSource.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
To solve the issue were a consumer gets stuck trying to receive a message from the Pulsar server due to network drops, this PR adds a watchdog. [https://github.com/apache/pulsar-dotpulsar/issues/84](https://github.com/apache/pulsar-dotpulsar/issues/84)
The watchdog is disabled by default, but can be enabled by setting a watchdog timeout in the PulsarClientBuilder.
The watchdog is "kicked" every time the connection receives a Pulsar message. If no message is received within the timeout timespan, a timer is cancelling a CancellationToken, aborting the receive attempt.