### PR TITLE
Change default behaviour on MetaDataException

### DIFF
--- a/src/DotPulsar/Internal/DefaultExceptionHandler.cs
+++ b/src/DotPulsar/Internal/DefaultExceptionHandler.cs
@@ -45,7 +45,7 @@ namespace DotPulsar.Internal
                 TooManyRequestsException _ => FaultAction.Retry,
                 ChannelNotReadyException _ => FaultAction.Retry,
                 ServiceNotReadyException _ => FaultAction.Retry,
-                MetadataException _ => FaultAction.Retry,
+                MetadataException _ => FaultAction.Rethrow,
                 ConsumerNotFoundException _ => FaultAction.Retry,
                 ConnectionDisposedException _ => FaultAction.Retry,
                 AsyncLockDisposedException _ => FaultAction.Retry,


### PR DESCRIPTION
Error occurs when tenant or namespace supplied in topic string does not exist.
org.apache.pulsar.broker.web.RestException: Policies not found for tenant/namespace namespace