### PR TITLE
add server timeout functionality plus docker test

### DIFF
--- a/DotPulsar.sln
+++ b/DotPulsar.sln
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Processing", "samples\Processing\Processing.csproj", "{CC1494FA-4EB5-4DB9-8BE9-0A6E8D0D963E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotPulsar.Consumer", "tests\DotPulsar.Consumer\DotPulsar.Consumer.csproj", "{36E6E6EF-A471-4AE4-B696-1C9DAAFA2770}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{CC1494FA-4EB5-4DB9-8BE9-0A6E8D0D963E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC1494FA-4EB5-4DB9-8BE9-0A6E8D0D963E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC1494FA-4EB5-4DB9-8BE9-0A6E8D0D963E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36E6E6EF-A471-4AE4-B696-1C9DAAFA2770}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36E6E6EF-A471-4AE4-B696-1C9DAAFA2770}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36E6E6EF-A471-4AE4-B696-1C9DAAFA2770}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36E6E6EF-A471-4AE4-B696-1C9DAAFA2770}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,6 +72,7 @@ Global
 		{14934BED-A222-47B2-A58A-CFC4AAB89B49} = {E7106D0F-B255-4631-9FB8-734FC5748FA9}
 		{6D44683B-865C-4D15-9F0A-1A8441354589} = {E7106D0F-B255-4631-9FB8-734FC5748FA9}
 		{CC1494FA-4EB5-4DB9-8BE9-0A6E8D0D963E} = {E7106D0F-B255-4631-9FB8-734FC5748FA9}
+		{36E6E6EF-A471-4AE4-B696-1C9DAAFA2770} = {E1C932A9-6D4C-4DDF-8922-BE7B71F12F1C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {88355922-E70A-4B73-B7F8-ABF8F2B59789}

--- a/src/DotPulsar/Abstractions/IPulsarClientBuilder.cs
+++ b/src/DotPulsar/Abstractions/IPulsarClientBuilder.cs
@@ -54,6 +54,16 @@ public interface IPulsarClientBuilder
     IPulsarClientBuilder KeepAliveInterval(TimeSpan interval);
 
     /// <summary>
+    /// The maximum amount of time to wait without receiving any message from the server at
+    /// which point the connection is assumed to be dead or the server is not responding.
+    /// As we are sending pings the server should respond to those at a minimum within this specified timeout period.
+    /// Once this happens the connection will be torn down and all consumers/producers will enter
+    /// the disconnected state and attempt to reconnect
+    /// The default is 60 seconds.
+    /// </summary>
+    IPulsarClientBuilder ServerResponseTimeout(TimeSpan interval);
+
+    /// <summary>
     /// Set the listener name. This is optional.
     /// </summary>
     IPulsarClientBuilder ListenerName(string listenerName);

--- a/src/DotPulsar/Internal/Connection.cs
+++ b/src/DotPulsar/Internal/Connection.cs
@@ -33,11 +33,15 @@ public sealed class Connection : IConnection
     private readonly IAuthentication? _authentication;
     private int _isDisposed;
 
-    public Connection(IPulsarStream stream, TimeSpan keepAliveInterval, IAuthentication? authentication)
+    public Connection(
+        IPulsarStream stream,
+        TimeSpan keepAliveInterval,
+        TimeSpan serverResponseTimeout,
+        IAuthentication? authentication)
     {
         _lock = new AsyncLock();
         _channelManager = new ChannelManager();
-        _pingPongHandler = new PingPongHandler(this, keepAliveInterval);
+        _pingPongHandler = new PingPongHandler(this, keepAliveInterval, serverResponseTimeout);
         _stream = stream;
         _authentication = authentication;
     }
@@ -294,6 +298,11 @@ public sealed class Connection : IConnection
     }
 
     public async Task ProcessIncommingFrames(CancellationToken cancellationToken)
+    {
+        await Task.WhenAny(ProcessIncommingFramesImpl(cancellationToken), _pingPongHandler.ServerNotResponding);
+    }
+
+    public async Task ProcessIncommingFramesImpl(CancellationToken cancellationToken)
     {
         await Task.Yield();
 

--- a/src/DotPulsar/Internal/DotPulsarMeter.cs
+++ b/src/DotPulsar/Internal/DotPulsarMeter.cs
@@ -29,6 +29,7 @@ public static class DotPulsarMeter
     private static int _numberOfReaders;
     private static int _numberOfConsumers;
     private static int _numberOfProducers;
+    private static int _numberOfServerTimeouts;
 #pragma warning restore IDE0044
 #pragma warning restore IDE0079
     private static readonly Histogram<double> _producerSendDuration;
@@ -42,6 +43,7 @@ public static class DotPulsarMeter
         _ = Meter.CreateObservableGauge("dotpulsar.reader.count", GetNumberOfReaders, "{readers}", "Number of readers");
         _ = Meter.CreateObservableGauge("dotpulsar.consumer.count", GetNumberOfConsumers, "{consumers}", "Number of consumers");
         _ = Meter.CreateObservableGauge("dotpulsar.producer.count", GetNumberOfProducers, "{producers}", "Number of producers");
+        _ = Meter.CreateObservableGauge("dotpulsar.server.timeout.count", GetNumberOfProducers, "{servertimeout}", "Number of times server stopped responding");
         _producerSendDuration = Meter.CreateHistogram<double>("dotpulsar.producer.send.duration", "ms", "Measures the duration for sending a message");
         _consumerProcessDuration = Meter.CreateHistogram<double>("dotpulsar.consumer.process.duration", "ms", "Measures the duration for processing a message");
     }
@@ -54,6 +56,7 @@ public static class DotPulsarMeter
 
     public static void ConnectionCreated() => Interlocked.Increment(ref _numberOfConnections);
     public static void ConnectionDisposed() => Interlocked.Decrement(ref _numberOfConnections);
+    public static void ServerTimedout() => Interlocked.Decrement(ref _numberOfServerTimeouts);
     private static int GetNumberOfConnections() => Volatile.Read(ref _numberOfConnections);
 
     public static void ReaderCreated() => Interlocked.Increment(ref _numberOfReaders);
@@ -67,6 +70,7 @@ public static class DotPulsarMeter
     public static void ProducerCreated() => Interlocked.Increment(ref _numberOfProducers);
     public static void ProducerDisposed() => Interlocked.Decrement(ref _numberOfProducers);
     private static int GetNumberOfProducers() => Volatile.Read(ref _numberOfProducers);
+    private static int GetNumberOfServerTimeouts() => Volatile.Read(ref _numberOfServerTimeouts);
 
 
     public static bool MessageSentEnabled => _producerSendDuration.Enabled;

--- a/src/DotPulsar/Internal/PingPongHandler.cs
+++ b/src/DotPulsar/Internal/PingPongHandler.cs
@@ -25,21 +25,29 @@ public sealed class PingPongHandler : IAsyncDisposable
 {
     private readonly IConnection _connection;
     private readonly TimeSpan _keepAliveInterval;
+    private readonly TimeSpan _serverResponseTimeout;
     private readonly Timer _timer;
     private readonly CommandPing _ping;
     private readonly CommandPong _pong;
     private long _lastCommand;
+    private readonly TaskCompletionSource<object> _serverNotRespondingTcs;
 
-    public PingPongHandler(IConnection connection, TimeSpan keepAliveInterval)
+    public PingPongHandler(IConnection connection,
+        TimeSpan keepAliveInterval,
+        TimeSpan serverResponseTimeout)
     {
         _connection = connection;
         _keepAliveInterval = keepAliveInterval;
+        _serverResponseTimeout = serverResponseTimeout;
         _timer = new Timer(Watch);
         _timer.Change(_keepAliveInterval, TimeSpan.Zero);
         _ping = new CommandPing();
         _pong = new CommandPong();
         _lastCommand = Stopwatch.GetTimestamp();
+        _serverNotRespondingTcs = new TaskCompletionSource<object>();
     }
+
+    public Task ServerNotResponding => _serverNotRespondingTcs.Task;
 
     public bool Incoming(BaseCommand.Type commandType)
     {
@@ -47,7 +55,7 @@ public sealed class PingPongHandler : IAsyncDisposable
 
         if (commandType == BaseCommand.Type.Ping)
         {
-            Task.Factory.StartNew(() => SendPong());
+            Task.Factory.StartNew(SendPong);
             return true;
         }
 
@@ -61,13 +69,25 @@ public sealed class PingPongHandler : IAsyncDisposable
             var lastCommand = Interlocked.Read(ref _lastCommand);
             var now = Stopwatch.GetTimestamp();
             var elapsed = TimeSpan.FromSeconds((now - lastCommand) / Stopwatch.Frequency);
-            if (elapsed >= _keepAliveInterval)
+
+            if (elapsed > _serverResponseTimeout)
             {
-                Task.Factory.StartNew(() => SendPing());
-                _timer.Change(_keepAliveInterval, TimeSpan.Zero);
+                DotPulsarMeter.ServerTimedout();
+                _serverNotRespondingTcs.SetResult(new object());
             }
             else
-                _timer.Change(_keepAliveInterval.Subtract(elapsed), TimeSpan.Zero);
+            {
+                if (elapsed >= _keepAliveInterval)
+                {
+                    Task.Factory.StartNew(() => SendPing());
+                    _timer.Change(_keepAliveInterval, TimeSpan.Zero);
+                }
+                else
+                {
+                    var result = _keepAliveInterval.Subtract(elapsed);
+                    _timer.Change(result, TimeSpan.Zero);
+                }
+            }
         }
         catch
         {

--- a/tests/DotPulsar.Consumer/DotPulsar.Consumer.csproj
+++ b/tests/DotPulsar.Consumer/DotPulsar.Consumer.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+      <TargetFramework>net6.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <OutputType>Exe</OutputType>
+      <Nullable>enable</Nullable>
+      <PublishSingleFile>true</PublishSingleFile>
+      <DebugType>embedded</DebugType>
+      <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\DotPulsar\DotPulsar.csproj" />
+    </ItemGroup>
+
+  <Target Name="PublishConsumer" AfterTargets="Build">
+    <Exec Command="dotnet publish $(ProjectDir) -r linux-x64 -o $(SolutionDir)tests\DotPulsar.Tests\$(OutDir) --no-build"
+          ConsoleToMSBuild="true" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="ConsoleOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
+    </Exec>
+
+    <Error Condition="'$(ExitCode)' != '0'" Text="$(ConsoleOutput)"  />
+  </Target>
+</Project>

--- a/tests/DotPulsar.Consumer/Program.cs
+++ b/tests/DotPulsar.Consumer/Program.cs
@@ -1,0 +1,95 @@
+﻿namespace DotPulsar.Consumer;
+
+using Abstractions;
+using Extensions;
+using Internal;
+using System.Net.Sockets;
+
+public static class Program
+{
+    public const string ConnectedAwaitingDisconnection = "Successfully connected, awaiting disconnection";
+    public const string DisconnectedAwaitingReconnection = "Successfully disconnected, awaiting reconnection";
+    public const string Reconnected = "Successfully reconnected";
+
+    public static async Task<int> Main(string[] args)
+    {
+        Console.WriteLine($"Running with url {args[0]}");
+        var client = CreateClient(args[0], args[1]);
+
+        var testRunId = Guid.NewGuid().ToString("N");
+
+        var topic = $"persistent://public/default/consumer-tests-{testRunId}";
+        await using var consumer = client.NewConsumer(Schema.ByteArray)
+            .ConsumerName($"consumer-{testRunId}")
+            .InitialPosition(SubscriptionInitialPosition.Earliest)
+            .SubscriptionName($"subscription-{testRunId}")
+            .StateChangedHandler(changed => Console.WriteLine($"Consumer state changed to {changed.ConsumerState}"))
+            .Topic(topic)
+            .Create();
+
+        var timeout = Task.Delay(TimeSpan.FromSeconds(30));
+        var result = await Task.WhenAny(timeout, consumer.StateChangedTo(ConsumerState.Active).AsTask());
+
+        if (result == timeout)
+        {
+            Console.WriteLine("Timed out waiting for active status");
+            return -1;
+        }
+
+        Console.WriteLine(ConnectedAwaitingDisconnection);
+        timeout = Task.Delay(TimeSpan.FromSeconds(30));
+        result = await Task.WhenAny(timeout, consumer.StateChangedTo(ConsumerState.Disconnected).AsTask());
+
+        if (result == timeout)
+        {
+            Console.WriteLine("Timed out waiting for disconnected status");
+            return -2;
+        }
+
+        Console.WriteLine(DisconnectedAwaitingReconnection);
+        timeout = Task.Delay(TimeSpan.FromSeconds(30));
+        result = await Task.WhenAny(timeout, consumer.StateChangedTo(ConsumerState.Active).AsTask());
+
+        if (result == timeout)
+        {
+            Console.WriteLine("Timed out waiting for reconnected status");
+            return -3;
+        }
+
+        Console.WriteLine(Reconnected);
+        return 0;
+    }
+
+    private static IPulsarClient CreateClient(string url, string token)
+        => PulsarClient
+            .Builder()
+            .Authentication(AuthenticationFactory.Token(_ => ValueTask.FromResult(token)))
+            .KeepAliveInterval(TimeSpan.FromSeconds(5))
+            .ServerResponseTimeout(TimeSpan.FromSeconds(10))
+            .ExceptionHandler(new TestExceptionHandler())
+            .ServiceUrl(new Uri(url))
+            .Build();
+}
+
+internal class TestExceptionHandler : IHandleException
+{
+    private readonly IHandleException _inner = new DefaultExceptionHandler(TimeSpan.FromSeconds(5));
+
+    public ValueTask OnException(ExceptionContext exceptionContext)
+    {
+        Console.WriteLine("Exception occurred: {0}", exceptionContext.Exception.Message);
+
+        // This occurs when reconnecting the docker network, it takes some time for the alias to be reestablished
+        if (exceptionContext.Exception is SocketException se && se.Message.Contains("Name or service not known"))
+        {
+            exceptionContext.ExceptionHandled = true;
+            exceptionContext.Result = FaultAction.Retry;
+        }
+        else
+        {
+            _inner.OnException(exceptionContext);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/DotPulsar.Tests/DotPulsar.Tests.csproj
+++ b/tests/DotPulsar.Tests/DotPulsar.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotPulsar\DotPulsar.csproj" />
+    <ProjectReference Include="..\DotPulsar.Consumer\DotPulsar.Consumer.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DotPulsar.Tests/IntegrationCollection.cs
+++ b/tests/DotPulsar.Tests/IntegrationCollection.cs
@@ -18,3 +18,6 @@ using Xunit;
 
 [CollectionDefinition("Integration")]
 public class IntegrationCollection : ICollectionFixture<IntegrationFixture> { }
+
+[CollectionDefinition("KeepAlive")]
+public class KeepAliveCollection : ICollectionFixture<KeepAliveFixture> { }

--- a/tests/DotPulsar.Tests/IntegrationFixture.cs
+++ b/tests/DotPulsar.Tests/IntegrationFixture.cs
@@ -15,9 +15,11 @@
 namespace DotPulsar.Tests;
 
 using Ductus.FluentDocker.Builders;
+using Ductus.FluentDocker.Commands;
 using Ductus.FluentDocker.Services;
 using Ductus.FluentDocker.Services.Extensions;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -32,56 +34,78 @@ public class IntegrationFixture : IAsyncLifetime
     private const int Port = 6650;
 
     private readonly IMessageSink _messageSink;
-    private readonly IContainerService _cluster;
+    private IContainerService? _cluster;
+    private INetworkService? _network;
+
+    protected virtual string[] EnvironmentVariables => new[]
+    {
+        $"PULSAR_PREFIX_tokenSecretKey=file://{SecretKeyPath}",
+        "PULSAR_PREFIX_authenticationRefreshCheckSeconds=5",
+        $"superUserRoles={UserName}",
+        "authenticationEnabled=true",
+        "authorizationEnabled=true",
+        "authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken",
+        "authenticateOriginalAuthData=false",
+        $"brokerClientAuthenticationPlugin={AuthenticationPlugin}",
+        $"CLIENT_PREFIX_authPlugin={AuthenticationPlugin}",
+    };
+
+    protected virtual bool IncludeNetwork => false;
 
     public IntegrationFixture(IMessageSink messageSink)
     {
         _messageSink = messageSink;
-
-        var environmentVariables = new[]
-        {
-            $"PULSAR_PREFIX_tokenSecretKey=file://{SecretKeyPath}",
-            "PULSAR_PREFIX_authenticationRefreshCheckSeconds=5",
-            $"superUserRoles={UserName}",
-            "authenticationEnabled=true",
-            "authorizationEnabled=true",
-            "authenticationProviders=org.apache.pulsar.broker.authentication.AuthenticationProviderToken",
-            "authenticateOriginalAuthData=false",
-            $"brokerClientAuthenticationPlugin={AuthenticationPlugin}",
-            $"CLIENT_PREFIX_authPlugin={AuthenticationPlugin}",
-        };
-
-        var arguments = "\"" +
-            $"bin/pulsar tokens create-secret-key --output {SecretKeyPath} && " +
-            $"export brokerClientAuthenticationParameters=token:$(bin/pulsar tokens create --secret-key {SecretKeyPath} --subject {UserName}) && " +
-            "export CLIENT_PREFIX_authParams=$brokerClientAuthenticationParameters && " +
-            "bin/apply-config-from-env.py conf/standalone.conf && " +
-            "bin/apply-config-from-env-with-prefix.py CLIENT_PREFIX_ conf/client.conf && " +
-            "bin/pulsar standalone --no-functions-worker"
-            + "\"";
-
-        _cluster = new Builder()
-            .UseContainer()
-            .UseImage("apachepulsar/pulsar:2.9.2")
-            .WithEnvironment(environmentVariables)
-            .ExposePort(Port)
-            .Command("/bin/bash -c", arguments)
-            .Build();
-
+        var instanceId = Guid.NewGuid().ToString();
+        PulsarContainerName = $"dotpulsar-pulsar.{instanceId}";
+        NetworkAlias = $"dotpulsar-network.{instanceId}";
         ServiceUrl = new Uri("pulsar://localhost:6650");
     }
 
     public Uri ServiceUrl { get; private set; }
+    public string NetworkAlias { get; }
+    public string PulsarContainerName { get; }
 
     public Task DisposeAsync()
     {
-        _cluster.Dispose();
+        _cluster?.Dispose();
+        _network?.Dispose();
         return Task.CompletedTask;
     }
 
     public Task InitializeAsync()
     {
-        _cluster.StateChange += (sender, args) => _messageSink.OnMessage(new DiagnosticMessage($"The Pulsar cluster changed state to: {args.State}"));
+        var arguments = "\"" +
+                        $"bin/pulsar tokens create-secret-key --output {SecretKeyPath} && " +
+                        $"export brokerClientAuthenticationParameters=token:$(bin/pulsar tokens create --secret-key {SecretKeyPath} --subject {UserName}) && " +
+                        "export CLIENT_PREFIX_authParams=$brokerClientAuthenticationParameters && " +
+                        "bin/apply-config-from-env.py conf/standalone.conf && " +
+                        "bin/apply-config-from-env-with-prefix.py CLIENT_PREFIX_ conf/client.conf && " +
+                        "bin/pulsar standalone --no-functions-worker"
+                        + "\"";
+
+        var docker= new Hosts().Discover().Single();
+
+        if (IncludeNetwork)
+        {
+            _network = docker.CreateNetwork(NetworkAlias, removeOnDispose:true);
+        }
+
+        var builder = new Builder()
+            .UseContainer()
+            .WithName(PulsarContainerName)
+            .UseImage("apachepulsar/pulsar:2.9.2")
+            .WithEnvironment(EnvironmentVariables)
+            .WithHostName("pulsar")
+            .ExposePort(Port)
+            .Command("/bin/bash -c", arguments);
+
+        if (IncludeNetwork)
+        {
+            builder = builder.UseNetwork(NetworkAlias);
+        }
+
+        _cluster = builder.Build();
+        _cluster.StateChange += (_, args) => _messageSink.OnMessage(new DiagnosticMessage($"The Pulsar cluster changed state to: {args.State}"));
         _cluster.Start();
         _cluster.WaitForMessageInLogs("Successfully updated the policies on namespace public/default", int.MaxValue);
         var endpoint = _cluster.ToHostExposedEndpoint($"{Port}/tcp");
@@ -113,5 +137,19 @@ public class IntegrationFixture : IAsyncLifetime
 
         if (!result.Success)
             throw new Exception($"Could not create the partitioned topic: {result.Error}");
+    }
+
+    public void DisconnectBroker()
+    {
+        var hosts = new Hosts().Discover();
+        var docker = hosts.Single();
+        docker.Host.NetworkDisconnect(PulsarContainerName, NetworkAlias, true);
+    }
+
+    public void ReconnectBroker()
+    {
+        var hosts = new Hosts().Discover();
+        var docker = hosts.Single();
+        docker.Host.NetworkConnect(PulsarContainerName, NetworkAlias, new[] { "pulsar" });
     }
 }

--- a/tests/DotPulsar.Tests/IntegrationFixture.cs
+++ b/tests/DotPulsar.Tests/IntegrationFixture.cs
@@ -15,7 +15,6 @@
 namespace DotPulsar.Tests;
 
 using Ductus.FluentDocker.Builders;
-using Ductus.FluentDocker.Commands;
 using Ductus.FluentDocker.Services;
 using Ductus.FluentDocker.Services.Extensions;
 using System;
@@ -137,19 +136,5 @@ public class IntegrationFixture : IAsyncLifetime
 
         if (!result.Success)
             throw new Exception($"Could not create the partitioned topic: {result.Error}");
-    }
-
-    public void DisconnectBroker()
-    {
-        var hosts = new Hosts().Discover();
-        var docker = hosts.Single();
-        docker.Host.NetworkDisconnect(PulsarContainerName, NetworkAlias, true);
-    }
-
-    public void ReconnectBroker()
-    {
-        var hosts = new Hosts().Discover();
-        var docker = hosts.Single();
-        docker.Host.NetworkConnect(PulsarContainerName, NetworkAlias, new[] { "pulsar" });
     }
 }

--- a/tests/DotPulsar.Tests/KeepAliveFixture.cs
+++ b/tests/DotPulsar.Tests/KeepAliveFixture.cs
@@ -1,5 +1,7 @@
 ﻿namespace DotPulsar.Tests;
 
+using Ductus.FluentDocker.Commands;
+using Ductus.FluentDocker.Services;
 using System.Linq;
 using Xunit.Abstractions;
 
@@ -13,4 +15,18 @@ public class KeepAliveFixture : IntegrationFixture
     protected override bool IncludeNetwork => true;
 
     protected override string[] EnvironmentVariables => base.EnvironmentVariables.Concat(new[] { "keepAliveIntervalSeconds=5" }).ToArray();
+
+    public void DisconnectBroker()
+    {
+        var hosts = new Hosts().Discover();
+        var docker = hosts.Single();
+        docker.Host.NetworkDisconnect(PulsarContainerName, NetworkAlias, true);
+    }
+
+    public void ReconnectBroker()
+    {
+        var hosts = new Hosts().Discover();
+        var docker = hosts.Single();
+        docker.Host.NetworkConnect(PulsarContainerName, NetworkAlias, new[] { "pulsar" });
+    }
 }

--- a/tests/DotPulsar.Tests/KeepAliveFixture.cs
+++ b/tests/DotPulsar.Tests/KeepAliveFixture.cs
@@ -1,0 +1,16 @@
+﻿namespace DotPulsar.Tests;
+
+using System.Linq;
+using Xunit.Abstractions;
+
+public class KeepAliveFixture : IntegrationFixture
+{
+    public KeepAliveFixture(IMessageSink messageSink) : base(messageSink)
+    {
+
+    }
+
+    protected override bool IncludeNetwork => true;
+
+    protected override string[] EnvironmentVariables => base.EnvironmentVariables.Concat(new[] { "keepAliveIntervalSeconds=5" }).ToArray();
+}

--- a/tests/DotPulsar.Tests/KeepAliveTests.cs
+++ b/tests/DotPulsar.Tests/KeepAliveTests.cs
@@ -1,0 +1,112 @@
+namespace DotPulsar.Tests;
+
+using Abstractions;
+using Extensions;
+using Consumer;
+using Ductus.FluentDocker.Builders;
+using Ductus.FluentDocker.Model.Builders;
+using Ductus.FluentDocker.Services.Extensions;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+[Collection("KeepAlive"), Trait("Category", "KeepAlive")]
+public class KeepAliveTests
+{
+    private readonly KeepAliveFixture _fixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public KeepAliveTests(KeepAliveFixture fixture, ITestOutputHelper outputHelper)
+    {
+        _fixture = fixture;
+        _testOutputHelper = outputHelper;
+    }
+
+    [Fact]
+    public async Task TestNetworkDisconnection()
+    {
+        var token = _fixture.CreateToken(Timeout.InfiniteTimeSpan);
+
+        using var consumer = new Builder()
+            .UseContainer()
+            .UseImage("mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim")
+            .UseNetwork(_fixture.NetworkAlias)
+            .Mount(Path.Combine(Environment.CurrentDirectory, "linux-x64"), "/app", MountType.ReadOnly)
+            .Command("/app/DotPulsar.Consumer", "pulsar://pulsar:6650", token)
+            .Build()
+            .Start();
+
+        var reconnected = false;
+        var logsTask = Task.Run(() =>
+        {
+            var logs = consumer.Logs(true);
+
+            while (!logs.IsFinished)
+            {
+                var line = logs.TryRead(45_000); // Do a read with timeout
+
+                if (line != null)
+                {
+                    _testOutputHelper.WriteLine(line);
+                }
+            }
+
+            _testOutputHelper.WriteLine("Logs completed");
+        });
+
+        try
+        {
+            consumer.WaitForMessageInLogs(Program.ConnectedAwaitingDisconnection, 30_000);
+            _testOutputHelper.WriteLine("Severing network");
+            _fixture.DisconnectBroker();
+
+            consumer.WaitForMessageInLogs(Program.DisconnectedAwaitingReconnection, 30_000);
+            _testOutputHelper.WriteLine("Reconnecting network");
+            _fixture.ReconnectBroker();
+            reconnected = true;
+            consumer.WaitForMessageInLogs(Program.Reconnected, 30_000);
+        }
+        finally
+        {
+            if (!reconnected)
+            {
+                _fixture.ReconnectBroker();
+                await AssertReconnection();
+            }
+
+            consumer.Dispose();
+        }
+
+        await logsTask;
+    }
+
+    private async Task AssertReconnection()
+    {
+        await using var client = CreateClient();
+        string topicName = $"round-robin-partitioned-{Guid.NewGuid():N}";
+        await using var producer = client.NewProducer(Schema.String)
+            .Topic(topicName)
+            .Create();
+
+        var timeout = Task.Delay(TimeSpan.FromSeconds(30));
+        var result = await Task.WhenAny(timeout, producer.StateChangedTo(ProducerState.Connected).AsTask());
+
+        await producer.Send("message");
+
+        if (result == timeout)
+        {
+            throw new Exception("Timeout waiting for active status");
+        }
+    }
+
+    private IPulsarClient CreateClient()
+        => PulsarClient
+            .Builder()
+            .Authentication(AuthenticationFactory.Token(ct => ValueTask.FromResult(_fixture.CreateToken(Timeout.InfiniteTimeSpan))))
+            .ExceptionHandler(ec => _testOutputHelper.WriteLine($"Exception: {ec.Exception}"))
+            .ServiceUrl(_fixture.ServiceUrl)
+            .Build();
+}

--- a/tests/DotPulsar.Tests/ProducerTests.cs
+++ b/tests/DotPulsar.Tests/ProducerTests.cs
@@ -152,6 +152,7 @@ public class ProducerTests
         => PulsarClient
         .Builder()
         .Authentication(AuthenticationFactory.Token(ct => ValueTask.FromResult(_fixture.CreateToken(Timeout.InfiniteTimeSpan))))
+        .KeepAliveInterval(TimeSpan.FromSeconds(5))
         .ExceptionHandler(ec => _testOutputHelper.WriteLine($"Exception: {ec.Exception}"))
         .ServiceUrl(_fixture.ServiceUrl)
         .Build();


### PR DESCRIPTION
As mentioned in the keep alive section of the pulsar binary configuration [here](https://pulsar.apache.org/docs/v2.0.0-rc1-incubating/project/BinaryProtocol/) if the server stops responding to our pings when we have to assume the connection is no longer valid. We can't just rely on the transport to tell us if the connection is alive or not. I've implemented it based on any response from the server rather than specifically a pong, its open to debate if this is correct, I could go either way.

I've also added a test to demonstrate the bug which is fixed by my code in the `PingPongHandler`