### PR TITLE
Retain original stack trace when exception happens in Producer

### DIFF
--- a/src/DotPulsar/Internal/Producer.cs
+++ b/src/DotPulsar/Internal/Producer.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -226,7 +227,8 @@ public sealed class Producer<TMessage> : IProducer<TMessage>, IRegisterEvent
         {
             _ = await _state.StateChangedFrom(ProducerState.Disconnected, cancellationToken).ConfigureAwait(false);
             if (_throw is not null)
-                throw _throw;
+                //Retain original stack trace by throwing like this
+                ExceptionDispatchInfo.Capture(_throw).Throw();
         }
 
         if (_producerCount == 1)


### PR DESCRIPTION
Currently if an exception happens in the Producer, the stack trace will look like this:
```
      System.Net.Sockets.SocketException (11001): No such host is known.
         at DotPulsar.Internal.Producer`1.ChoosePartitions(MessageMetadata metadata, CancellationToken cancellationToken)
         at DotPulsar.Internal.Producer`1.Send(MessageMetadata metadata, TMessage message, CancellationToken cancellationToken)
         [... My own code here...]
```
There is no functionality in the ChoosePartitions method that generates a SocketException, making the stack trace a bit useless.

This PR throws the exception stored in the `_throw` variable using ExceptionDispatchInfo thus retaining the original stack trace. In the case of the SocketException above, this becomes:

```
System.Net.Sockets.SocketException (11001): No such host is known.
         at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
         at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource.GetResult(Int16 token)
         at System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
      --- End of stack trace from previous location ---
         at System.Net.Sockets.TcpClient.CompleteConnectAsync(Task task)
         at DotPulsar.Internal.Connector.GetStream(String host, Int32 port)
         at DotPulsar.Internal.Connector.Connect(Uri serviceUrl)
         at DotPulsar.Internal.ConnectionPool.EstablishNewConnection(PulsarUrl url, CancellationToken cancellationToken)
         at DotPulsar.Internal.ConnectionPool.GetConnection(PulsarUrl url, CancellationToken cancellationToken)
         at DotPulsar.Internal.ConnectionPool.GetConnection(Uri serviceUrl, CancellationToken cancellationToken)
         at DotPulsar.Internal.ConnectionPool.FindConnectionForTopic(String topic, CancellationToken cancellationToken)
         at DotPulsar.Internal.Producer`1.GetNumberOfPartitions(String topic, CancellationToken cancellationToken)
         at DotPulsar.Internal.Producer`1.Monitor()
         at DotPulsar.Internal.Executor.Execute(Func`1 func, CancellationToken cancellationToken)
         at DotPulsar.Internal.Executor.Execute(Func`1 func, CancellationToken cancellationToken)
         at DotPulsar.Internal.Producer`1.Setup()
         at DotPulsar.Internal.Producer`1.ChoosePartitions(MessageMetadata metadata, CancellationToken cancellationToken)
         at DotPulsar.Internal.Producer`1.Send(MessageMetadata metadata, TMessage message, CancellationToken cancellationToken)
         [... My own code here...]
```
which points to where the error actually happens :)