### PR TITLE
modified the "hello world" to fix first run issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Have a look at the [changelog](CHANGELOG.md).
 
 ## Getting Started
 
-Let's take a look at a "Hello world" example, where we first produce a message and then consume it.
+Let's take a look at a "Hello world" example, where we create our consumer, produce a message, and then consume it. Note that the topic and subscription will be created if they don't exist.
 
 First, we need a Pulsar setup. Have a look [here](https://pulsar.apache.org/docs/en/standalone-docker/) to see how to setup a local standalone Pulsar instance.
 Install the NuGet package [DotPulsar](https://www.nuget.org/packages/DotPulsar/) and copy/paste the code below (you will be needing using declarations for 'DotPulsar' and 'DotPulsar.Extensions').
@@ -22,17 +22,17 @@ const string myTopic = "persistent://public/default/mytopic";
 
 await using var client = PulsarClient.Builder()
                                      .Build(); // Connecting to pulsar://localhost:6650
-
+                                     
+await using var consumer = client.NewConsumer(Schema.String)
+                                 .SubscriptionName("MySubscription")
+                                 .Topic(myTopic)
+                                 .Create();
+                                 
 await using var producer = client.NewProducer(Schema.String)
                                  .Topic(myTopic)
                                  .Create();
 
 _ = await producer.Send("Hello World"); // Send a message and ignore the returned MessageId
-
-await using var consumer = client.NewConsumer(Schema.String)
-                                 .SubscriptionName("MySubscription")
-                                 .Topic(myTopic)
-                                 .Create();
 
 await foreach (var message in consumer.Messages())
 {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Have a look at the [changelog](CHANGELOG.md).
 
 ## Getting Started
 
-Let's take a look at a "Hello world" example, where we create our consumer, produce a message, and then consume it. Note that the topic and subscription will be created if they don't exist.
+Let's take a look at a "Hello world" example, where we first produce a message and then consume it. Note that the topic and subscription will be created if they don't exist.
 
 First, we need a Pulsar setup. Have a look [here](https://pulsar.apache.org/docs/en/standalone-docker/) to see how to setup a local standalone Pulsar instance.
 Install the NuGet package [DotPulsar](https://www.nuget.org/packages/DotPulsar/) and copy/paste the code below (you will be needing using declarations for 'DotPulsar' and 'DotPulsar.Extensions').
@@ -22,17 +22,18 @@ const string myTopic = "persistent://public/default/mytopic";
 
 await using var client = PulsarClient.Builder()
                                      .Build(); // Connecting to pulsar://localhost:6650
-                                     
-await using var consumer = client.NewConsumer(Schema.String)
-                                 .SubscriptionName("MySubscription")
-                                 .Topic(myTopic)
-                                 .Create();
-                                 
+
 await using var producer = client.NewProducer(Schema.String)
                                  .Topic(myTopic)
                                  .Create();
 
 _ = await producer.Send("Hello World"); // Send a message and ignore the returned MessageId
+
+await using var consumer = client.NewConsumer(Schema.String)
+                                 .SubscriptionName("MySubscription")
+                                 .Topic(myTopic)
+                                 .InitialPosition(SubscriptionInitialPosition.Earliest)
+                                 .Create();
 
 await foreach (var message in consumer.Messages())
 {


### PR DESCRIPTION
the current "hello world" will not show a consumed message the very first time it is run. On subsequent runs, it will work, but it isn't entirely clear from the code alone why it works on subsequent runs.

I don't entirely understand why the order matters here, but I believe it isn't showing the consumed message on the first run because the subscription is created after the producer sends a message. It seems that by default, a new subscription will not consume messages that are created before it.

An alternative solution would be to create the consumer with the "InitialPosition" option set to Earliest (".InitialPosition(SubscriptionInitialPosition.Earliest"), but I think it's preferable to minimize optional configuration in a hello world like this.