### PR TITLE
Issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug Report
+description: Create a report to help us improve
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We welcome bug reports! Please see our [contribution guidelines](https://github.com/apache/pulsar-dotpulsar/blob/master/CONTRIBUTING.md#writing-a-good-bug-report) for more information on writing a good bug report. This template will help us gather the information we need to start the triage process.
+  - type: textarea
+    id: background
+    attributes:
+      label: Description
+      description: Please share a clear and concise description of the problem.
+      placeholder: Description
+    validations:
+      required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Reproduction Steps
+      description: |
+        Please include minimal steps to reproduce the problem if possible. E.g.: the smallest possible code snippet; or a small project, with steps to run it. If possible include text as text rather than screenshots (so it shows up in searches).
+      placeholder: Minimal Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: |
+        Provide a description of the expected behavior.
+      placeholder: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: |
+        Provide a description of the actual behavior observed. If applicable please include any error messages, exception stacktraces or memory dumps.
+      placeholder: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: regression
+    attributes:
+      label: Regression?
+      description: |
+        Did this work in a previous build or release of .NET Core, or from .NET Framework? If you can try a previous release or build to find out, that can help us narrow down the problem. If you don't know, that's OK.
+      placeholder: Regression?
+    validations:
+      required: false
+  - type: textarea
+    id: known-workarounds
+    attributes:
+      label: Known Workarounds
+      description: |
+        Please provide a description of any known workarounds.
+      placeholder: Known Workarounds
+    validations:
+      required: false
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Configuration
+      description: |
+        Please provide more information on your .NET configuration:
+          * Which version of .NET is the code running on?
+          * What OS and version, and what distro if applicable?
+          * What is the architecture (x64, x86, ARM, ARM64)?
+          * Do you know whether it is specific to that configuration?
+          * If you're using Blazor, which web browser(s) do you see this issue in?
+      placeholder: Configuration
+    validations:
+      required: false
+  - type: textarea
+    id: other-info
+    attributes:
+      label: Other information
+      description: |
+        If you have an idea where the problem might lie, let us know that here. Please include any pointers to code, relevant changes, or related issues you know of.
+      placeholder: Other information
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,0 +1,30 @@
+name: API or feature suggestion
+description: Propose a feature to dotpulsar
+labels: ["enhancement"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to put the feature or suggestion forward!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe
+      description: A clear and concise description of what the problem is. E.g., _I'm always frustrated when..._.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe the solution you'd like and alternatives you've considered
+      description: |
+        A clear and concise description of what you want to happen. This includes:
+        - Description of what API need to be added or changed.
+        - Code that shows the surface area of the API.
+        - Code that shows real world scenarios, and how they would otherwise be handled.
+        - Details showing the usage/consumption of the proposed new API, and alternatives (e.g., not having this API).
+        - Any other context or screenshots about the feature request here.
+    validations:
+      required: true
+      

--- a/.github/ISSUE_TEMPLATE/03_blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/03_blank_issue.md
@@ -1,0 +1,8 @@
+---
+name: Blank issue
+about: Something that doesn't fit the other categories
+title: ''
+labels: ''
+assignees: ''
+
+---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Good bug reports make it easier for maintainers to verify and root cause the und
 * Information on the environment: OS/distro, CPU arch, SDK version, etc.
 * Additional information, e.g. are there any known workarounds?
 
-When ready to submit a bug report, please use the [Bug Report issue template](https://github.com/apache/pulsar-dotpulsar/issues/new).
+When ready to submit a bug report, please use the [Bug Report issue template](https://github.com/apache/pulsar-dotpulsar/issues/new?assignees=&labels=&template=01_bug_report.yml).
 
 #### Why are Minimal Reproductions Important?
 


### PR DESCRIPTION
Moved CONTRIBUTING.md to the root. So it is easier to see therefore, users don't have to go into the docs folder to find it.

Added 3 issue templates

Used the new issue forms to create:
01_bug_report.yml bug reporting
02_feature_request.yml new feature requests

Used plain old markdown
03_blank_issue.md stuff that doesn't fit the other categories