### PR TITLE
cross platform compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 # All files
 [*]
 indent_style = space
+charset = utf-8
 
 # XML project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
@@ -21,7 +22,6 @@ tab_width = 4
 indent_size = 4
 
 # New line preferences
-end_of_line = crlf
 insert_final_newline = true
 ###############################
 # .NET Coding Conventions     #


### PR DESCRIPTION
Removed 
end_of_line = crlf. Line endings are OS specific and should not be part of .editorcofig.

Added 
charset = utf-8. Defaulting all file encodings to UTF-8.