### PR TITLE
Reduce allocations by not copying ReadOnlySequence

### DIFF
--- a/src/DotPulsar/Internal/Connection.cs
+++ b/src/DotPulsar/Internal/Connection.cs
@@ -308,7 +308,7 @@ public sealed class Connection : IConnection
                     continue;
 
                 if (command.CommandType == BaseCommand.Type.Message)
-                    _channelManager.Incoming(command.Message, new ReadOnlySequence<byte>(frame.Slice(commandSize + 4).ToArray()));
+                    _channelManager.Incoming(command.Message, frame.Slice(commandSize + 4));
                 else if (command.CommandType == BaseCommand.Type.AuthChallenge)
                     _ = Send(new CommandAuthResponse(), cancellationToken).ConfigureAwait(false);
                 else

--- a/src/DotPulsar/Internal/Consumer.cs
+++ b/src/DotPulsar/Internal/Consumer.cs
@@ -111,7 +111,7 @@ public sealed class Consumer<TMessage> : IEstablishNewChannel, IConsumer<TMessag
         ThrowIfDisposed();
 
         var command = new CommandRedeliverUnacknowledgedMessages();
-        command.MessageIds.AddRange(messageIds.Select(messageId => messageId.ToMessageIdData()));
+        command.MessageIds.AddRange(messageIds.Select(static messageId => messageId.ToMessageIdData()));
         await _executor.Execute(() => RedeliverUnacknowledgedMessages(command, cancellationToken), cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/DotPulsar/SchemaInfo.cs
+++ b/src/DotPulsar/SchemaInfo.cs
@@ -66,5 +66,5 @@ public sealed class SchemaInfo
     /// <summary>
     /// The properties of the schema.
     /// </summary>
-    public IReadOnlyDictionary<string, string> Properties => PulsarSchema.Properties.ToDictionary(p => p.Key, p => p.Value);
+    public IReadOnlyDictionary<string, string> Properties => PulsarSchema.Properties.ToDictionary(static p => p.Key, static p => p.Value);
 }


### PR DESCRIPTION
# Description

I recently started working at Danske Commodities where I had to use this library, and decided to peek around the source code a bit to see what it does. It seems to me that a significant amount of allocations could be avoided by not copying the slice to a new array in `Connection.cs` line 311, as the slice itself is already a `ReadOnlySequence<byte>`. I ran some simple benchmarks of performing such a copy (benchmark code and results is found below) that verifies that this indeed results in allocating the equivalent of the slice once more.
Besides changing this, I looked through the project and found a few places where the `static` modifier could be applied to reduce allocations for lambdas, but there were very few of these, probably because LINQ seems to be used very sparsely in the project.

# Benchmark results

```
|                             Method |      Mean |     Error |    StdDev |   Gen0 | Allocated |
|----------------------------------- |----------:|----------:|----------:|-------:|----------:|
|                ReturnSliceDirectly (Input = 256 B) |  8.699 ns | 0.1168 ns | 0.1093 ns |      - |         - |
| ReturnNewReadOnlySequenceFromArray (Input = 256 B) | 38.693 ns | 0.7455 ns | 0.7322 ns | 0.0485 |     152 B |


|                             Method |       Mean |     Error |    StdDev |   Gen0 | Allocated |
|----------------------------------- |-----------:|----------:|----------:|-------:|----------:|
|                ReturnSliceDirectly (Input = 2048 B) |   8.716 ns | 0.1092 ns | 0.1021 ns |      - |         - |
| ReturnNewReadOnlySequenceFromArray (Input = 2048 B) | 174.669 ns | 3.3067 ns | 3.3957 ns | 0.6194 |    1944 B |


|                             Method |         Mean |      Error |     StdDev |    Gen0 | Allocated |
|----------------------------------- |-------------:|-----------:|-----------:|--------:|----------:|
|                ReturnSliceDirectly (Input = 65536 B) |     8.748 ns |  0.1240 ns |  0.1160 ns |       - |         - |
| ReturnNewReadOnlySequenceFromArray (Input = 65536 B) | 4,809.186 ns | 78.2922 ns | 73.2346 ns | 20.4010 |   65432 B |
```

# Benchmark code

```
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Buffers;

[MemoryDiagnoser]
public class Program
{
    private static readonly ReadOnlySequence<byte> Input = new ReadOnlySequence<byte>(new byte[65536]);
    public static void Main()
    {
        BenchmarkRunner.Run<Program>();
        Console.ReadLine();
    }

    [Benchmark]
    public ReadOnlySequence<byte> ReturnSliceDirectly()
    {
        return Input.Slice(128);
    }

    [Benchmark]
    public ReadOnlySequence<byte> ReturnNewReadOnlySequenceFromArray()
    {
        return new ReadOnlySequence<byte>(Input.Slice(128).ToArray());
    }
}
```