### PR TITLE
Zstd compression test fix

### DIFF
--- a/tests/DotPulsar.Tests/Internal/Compression/ZstdCompressionTests.cs
+++ b/tests/DotPulsar.Tests/Internal/Compression/ZstdCompressionTests.cs
@@ -28,14 +28,7 @@ public class ZstdCompressionTests
     {
         // Arrange
         var couldLoad = ZstdCompression.TryLoading(out ICompressorFactory? compressorFactory, out IDecompressorFactory? decompressorFactory);
-
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            couldLoad.Should().BeFalse();
-            return;
-        }
-        else
-            couldLoad.Should().BeTrue();
+        couldLoad.Should().BeTrue();
 
         using var compressor = compressorFactory!.Create();
         using var decompressor = decompressorFactory!.Create();


### PR DESCRIPTION
Fixes zstd compression in the latest version is compiled to also work on linux

# Description

Fix test that was failing because it expected zstd compression not to work on linux

# Regression

Test started failing after update of zstdnet package
