### PR TITLE
Fix Producer.Send hang on reconnect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - If a consumer, reader, or producer is faulted all method calls will throw a ConsumerFaultedException, ProducerFaultedException, or ReaderFaultedException
 
+### Fixed
+
+- Fixed an issue introduced in `2.8.0`, where send operation would hang, after reestablishing the connection to the broker.
+
 ## [2.9.0] - 2023-01-26
 
 ### Added

--- a/src/DotPulsar/Internal/AsyncQueueWithCursor.cs
+++ b/src/DotPulsar/Internal/AsyncQueueWithCursor.cs
@@ -178,8 +178,7 @@ public sealed class AsyncQueueWithCursor<T> : IAsyncDisposable where T : IDispos
         }
         finally
         {
-            if (_cursorNextItemTcs is not null && _cursorNextItemTcs.Task.IsCanceled)
-                throw new TaskCanceledException("The task was cancelled");
+            bool shouldThrow = _cursorNextItemTcs is not null && _cursorNextItemTcs.Task.IsCanceled;
 
             lock (_queue)
             {
@@ -187,6 +186,11 @@ public sealed class AsyncQueueWithCursor<T> : IAsyncDisposable where T : IDispos
             }
 
             _cursorSemaphore.Release();
+
+            if (shouldThrow)
+            {
+                throw new TaskCanceledException("The task was cancelled");
+            }
         }
     }
 


### PR DESCRIPTION
Fixes Producer hang issue on reconnect

# Description

When disconnecting the semaphore preventing multiple NextItem() calls on AsyncQueueWithCursor was not properly released causing the next call on reconnect to wait forever.

# Regression

This fixes a problem introduced in 2.8.0, when the producer send logic was rewritten.

# Testing

Manual testing has been performed, but no integration tests are in place. I am not sure how we could implement an integration test for this.