### PR TITLE
Fix tests from previous pull request

### DIFF
--- a/src/DotPulsar/Internal/AsyncQueueWithCursor.cs
+++ b/src/DotPulsar/Internal/AsyncQueueWithCursor.cs
@@ -185,7 +185,14 @@ public sealed class AsyncQueueWithCursor<T> : IAsyncDisposable where T : IDispos
                 _cursorNextItemTcs = null;
             }
 
-            _cursorSemaphore.Release();
+            try
+            {
+                _cursorSemaphore.Release();
+            }
+            catch
+            {
+                // Ignore
+            }
 
             if (shouldThrow)
             {


### PR DESCRIPTION
Fixes Issue causing wrong exception to be thrown when MoveNext() call was cancelled because of the queue being disposed

# Description

Calling MoveNext() incorrectly threw ObjectDisposedException when the AsyncQueueWithCursor was disposed while the caller was waiting. Should be TaskCancelledException.

# Regression

Introduced by previous unreleased pull request.

# Testing

Issue was already covered by existing tests