### PR TITLE
Fix memory leak in Producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.2] - 2023-02-17
+
+### Fixed
+
+- Fixed a memory leak introduced in 2.8.0 with internal rewrite of producer functionality
+
 ## [2.10.1] - 2023-02-15
 
 ### Fixed

--- a/src/DotPulsar/Internal/Producer.cs
+++ b/src/DotPulsar/Internal/Producer.cs
@@ -257,9 +257,14 @@ public sealed class Producer<TMessage> : IProducer<TMessage>, IRegisterEvent
 
         await InternalSend(metadata, message, true, OnMessageSent, cancellationToken).ConfigureAwait(false);
 
-        var messageId = await tcs.Task.ConfigureAwait(false);
-        registration.Dispose();
-        return messageId;
+        try
+        {
+            return await tcs.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            registration.Dispose();
+        }
     }
 
     public async ValueTask Enqueue(MessageMetadata metadata, TMessage message, Func<MessageId, ValueTask>? onMessageSent = default, CancellationToken cancellationToken = default)

--- a/src/DotPulsar/Internal/Producer.cs
+++ b/src/DotPulsar/Internal/Producer.cs
@@ -243,7 +243,7 @@ public sealed class Producer<TMessage> : IProducer<TMessage>, IRegisterEvent
     public async ValueTask<MessageId> Send(MessageMetadata metadata, TMessage message, CancellationToken cancellationToken)
     {
         var tcs = new TaskCompletionSource<MessageId>();
-        cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+        var registration = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
 
         ValueTask OnMessageSent(MessageId messageId)
         {
@@ -257,7 +257,9 @@ public sealed class Producer<TMessage> : IProducer<TMessage>, IRegisterEvent
 
         await InternalSend(metadata, message, true, OnMessageSent, cancellationToken).ConfigureAwait(false);
 
-        return await tcs.Task.ConfigureAwait(false);
+        var messageId = await tcs.Task.ConfigureAwait(false);
+        registration.Dispose();
+        return messageId;
     }
 
     public async ValueTask Enqueue(MessageMetadata metadata, TMessage message, Func<MessageId, ValueTask>? onMessageSent = default, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Fixes Memory leak in producer

# Description

CancellationToken registration for Producer.Send operation was not correctly disposed

# Regression

Introduced in 2.8.0 with internal rewrite of producer functionality

# Testing

Manual testing with explicit garbage collection calls