### PR TITLE
Feature/object pooling issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - ?
+
+### Added
+
+- Support `ProducerAccessMode` to prevent multiple producers on a single topic.
+
+### Fixed
+
+- Fixed issue with `Send` extension methods that do include `MessageMetadata` in the parameter list. The issue prevents more than two messages from being published on namespaces where deduplication is enabled.
+
 ## [2.11.0] - 2023-03-13
 
 ### Added

--- a/src/DotPulsar/Extensions/SendChannelExtensions.cs
+++ b/src/DotPulsar/Extensions/SendChannelExtensions.cs
@@ -67,6 +67,7 @@ public static class SendChannelExtensions
 
         async ValueTask ReleaseMetadataAndCallCallback(MessageId id)
         {
+            metadata.Metadata.SequenceId = 0;
             metadata.Metadata.Properties.Clear();
             _messageMetadataPool.Return(metadata);
 

--- a/src/DotPulsar/Extensions/SendExtensions.cs
+++ b/src/DotPulsar/Extensions/SendExtensions.cs
@@ -71,6 +71,7 @@ public static class SendExtensions
         }
         finally
         {
+            metadata.Metadata.SequenceId = 0;
             metadata.Metadata.Properties.Clear();
             _messageMetadataPool.Return(metadata);
         }

--- a/src/DotPulsar/Internal/Abstractions/Process.cs
+++ b/src/DotPulsar/Internal/Abstractions/Process.cs
@@ -62,8 +62,6 @@ public abstract class Process : IProcess
                 ChannelState = ChannelState.Inactive;
                 break;
             case SendReceiptWrongOrdering _:
-                ChannelState = ChannelState.WrongAckOrdering;
-                break;
             case ChannelDisconnected _:
                 ChannelState = ChannelState.Disconnected;
                 break;

--- a/src/DotPulsar/Internal/ChannelState.cs
+++ b/src/DotPulsar/Internal/ChannelState.cs
@@ -19,7 +19,6 @@ public enum ChannelState : byte
     ClosedByServer,
     Connected,
     Disconnected,
-    WrongAckOrdering,
     ReachedEndOfTopic,
     Active,
     Inactive,

--- a/src/DotPulsar/Internal/ProducerProcess.cs
+++ b/src/DotPulsar/Internal/ProducerProcess.cs
@@ -60,7 +60,6 @@ public sealed class ProducerProcess : Process
         {
             case ChannelState.ClosedByServer:
             case ChannelState.Disconnected:
-            case ChannelState.WrongAckOrdering:
                 _stateManager.SetState(ProducerState.Disconnected);
                 _actionQueue.Enqueue(async x =>
                 {


### PR DESCRIPTION
Fixes Issue with Send extensions, that use object pooling for MessageMetadata.

# Description

The pooled MessageMetadata objects have SequenceId set as part of the send operation, but it was not reset when returned to the ObjectPool, causing the SequenceId to never change after sending two messages.

Additionally made minor cleanup and added a changelog entry.

# Testing

Manual testing on namespace with deduplication enabled