### PR TITLE
Producer access mode fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - Fixed issue with `Send` extension methods that do include `MessageMetadata` in the parameter list. The issue prevents more than two messages from being published on namespaces where deduplication is enabled.
+- Calling `await send(...)` on a Producer did not correctly terminate with an exception when a send operation failed, e.g. because the producer faulted.
 
 ## [2.11.0] - 2023-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 
 - Support `ProducerAccessMode` to prevent multiple producers on a single topic.
+- Added `Fenced` state for producers which is a final state. 
 
 ### Fixed
 

--- a/src/DotPulsar/Internal/Abstractions/IChannel.cs
+++ b/src/DotPulsar/Internal/Abstractions/IChannel.cs
@@ -23,6 +23,7 @@ public interface IChannel
     void ClosedByServer();
     void WaitingForExclusive();
     void Connected();
+    void ProducerConnected(ulong topicEpoch);
     void Deactivated();
     void Disconnected();
     void ReachedEndOfTopic();

--- a/src/DotPulsar/Internal/Abstractions/IContainsProducerChannel.cs
+++ b/src/DotPulsar/Internal/Abstractions/IContainsProducerChannel.cs
@@ -19,5 +19,5 @@ using System.Threading.Tasks;
 
 public interface IContainsProducerChannel : IContainsChannel
 {
-    Task ActivateChannel(CancellationToken cancellationToken);
+    Task ActivateChannel(ulong topicEpoch, CancellationToken cancellationToken);
 }

--- a/src/DotPulsar/Internal/Abstractions/IContainsProducerChannel.cs
+++ b/src/DotPulsar/Internal/Abstractions/IContainsProducerChannel.cs
@@ -19,5 +19,5 @@ using System.Threading.Tasks;
 
 public interface IContainsProducerChannel : IContainsChannel
 {
-    Task ActivateChannel(ulong topicEpoch, CancellationToken cancellationToken);
+    Task ActivateChannel(ulong? topicEpoch, CancellationToken cancellationToken);
 }

--- a/src/DotPulsar/Internal/Abstractions/IProducerChannel.cs
+++ b/src/DotPulsar/Internal/Abstractions/IProducerChannel.cs
@@ -22,7 +22,6 @@ using System.Threading.Tasks;
 
 public interface IProducerChannel : IAsyncDisposable
 {
-    ulong? TopicEpoch { get; }
     Task Send(MessageMetadata metadata, ReadOnlySequence<byte> payload, TaskCompletionSource<BaseCommand> responseTcs, CancellationToken cancellationToken);
     ValueTask ClosedByClient(CancellationToken cancellationToken);
 }

--- a/src/DotPulsar/Internal/Abstractions/Process.cs
+++ b/src/DotPulsar/Internal/Abstractions/Process.cs
@@ -32,9 +32,11 @@ public abstract class Process : IProcess
         ChannelState = ChannelState.Disconnected;
         ExecutorState = ExecutorState.Ok;
         CorrelationId = correlationId;
+        TopicEpoch = 0;
     }
 
     public Guid CorrelationId { get; }
+    protected ulong TopicEpoch { get; private set; }
 
     public void Start()
         => CalculateState();
@@ -56,6 +58,10 @@ public abstract class Process : IProcess
                 ChannelState = ChannelState.ClosedByServer;
                 break;
             case ChannelConnected _:
+                ChannelState = ChannelState.Connected;
+                break;
+            case ProducerChannelConnected producerChannelConnected:
+                TopicEpoch = producerChannelConnected.TopicEpoch;
                 ChannelState = ChannelState.Connected;
                 break;
             case ChannelDeactivated _:

--- a/src/DotPulsar/Internal/Abstractions/Process.cs
+++ b/src/DotPulsar/Internal/Abstractions/Process.cs
@@ -32,11 +32,10 @@ public abstract class Process : IProcess
         ChannelState = ChannelState.Disconnected;
         ExecutorState = ExecutorState.Ok;
         CorrelationId = correlationId;
-        TopicEpoch = 0;
     }
 
     public Guid CorrelationId { get; }
-    protected ulong TopicEpoch { get; private set; }
+    protected ulong? TopicEpoch { get; private set; }
 
     public void Start()
         => CalculateState();

--- a/src/DotPulsar/Internal/Channel.cs
+++ b/src/DotPulsar/Internal/Channel.cs
@@ -61,6 +61,9 @@ public sealed class Channel : IChannel
     public void Connected()
         => _eventRegister.Register(new ChannelConnected(_correlationId));
 
+    public void ProducerConnected(ulong topicEpoch)
+        => _eventRegister.Register(new ProducerChannelConnected(_correlationId, topicEpoch));
+
     public void Deactivated()
         => _eventRegister.Register(new ChannelDeactivated(_correlationId));
 

--- a/src/DotPulsar/Internal/ChannelManager.cs
+++ b/src/DotPulsar/Internal/ChannelManager.cs
@@ -262,7 +262,6 @@ public sealed class ChannelManager : IDisposable
     {
         _ = _requestResponseHandler.ExpectAdditionalResponse(command).ContinueWith(response =>
         {
-            // TODO: It is a bit unclear if this could ever fault or receive an error from the server
             if (response.IsCanceled || response.IsFaulted || response.Result.CommandType == BaseCommand.Type.Error)
             {
                 _producerChannels[command.ProducerId]?.Disconnected();

--- a/src/DotPulsar/Internal/ChannelManager.cs
+++ b/src/DotPulsar/Internal/ChannelManager.cs
@@ -59,15 +59,15 @@ public sealed class ChannelManager : IDisposable
 
             if (response.Result.ProducerSuccess.ProducerReady)
             {
-                channel.Connected();
+                channel.ProducerConnected(response.Result.ProducerSuccess.TopicEpoch);
             }
             else
             {
                 channel.WaitingForExclusive();
-                HandleAdditionalProducerSuccess(command, channel.Connected);
+                HandleAdditionalProducerSuccess(command, channel.ProducerConnected);
             }
 
-            return new ProducerResponse(producerId, response.Result.ProducerSuccess.ProducerName, response.Result.ProducerSuccess.TopicEpoch);
+            return new ProducerResponse(producerId, response.Result.ProducerSuccess.ProducerName);
         }, TaskContinuationOptions.OnlyOnRanToCompletion);
     }
 
@@ -258,7 +258,7 @@ public sealed class ChannelManager : IDisposable
         return channel.SenderLock();
     }
 
-    private void HandleAdditionalProducerSuccess(CommandProducer command, Action successAction)
+    private void HandleAdditionalProducerSuccess(CommandProducer command, Action<ulong> successAction)
     {
         _ = _requestResponseHandler.ExpectAdditionalResponse(command).ContinueWith(response =>
         {
@@ -267,7 +267,7 @@ public sealed class ChannelManager : IDisposable
                 HandleAdditionalProducerSuccess(command, successAction);
                 return;
             }
-            successAction.Invoke();
+            successAction.Invoke(response.Result.ProducerSuccess.TopicEpoch);
         });
     }
 }

--- a/src/DotPulsar/Internal/ChannelManager.cs
+++ b/src/DotPulsar/Internal/ChannelManager.cs
@@ -262,6 +262,12 @@ public sealed class ChannelManager : IDisposable
     {
         _ = _requestResponseHandler.ExpectAdditionalResponse(command).ContinueWith(response =>
         {
+            // TODO: It is a bit unclear if this could ever fault or receive an error from the server
+            if (response.IsCanceled || response.IsFaulted || response.Result.CommandType == BaseCommand.Type.Error)
+            {
+                _producerChannels[command.ProducerId]?.Disconnected();
+                return;
+            }
             if (!response.Result.ProducerSuccess.ProducerReady)
             {
                 HandleAdditionalProducerSuccess(command, successAction);

--- a/src/DotPulsar/Internal/Events/ProducerChannelConnected.cs
+++ b/src/DotPulsar/Internal/Events/ProducerChannelConnected.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,16 +12,20 @@
  * limitations under the License.
  */
 
-namespace DotPulsar.Internal;
+namespace DotPulsar.Internal.Events;
 
-public sealed class ProducerResponse
+using DotPulsar.Internal.Abstractions;
+using System;
+
+public sealed class ProducerChannelConnected : IEvent
 {
-    public ProducerResponse(ulong producerId, string producerName)
+    public ProducerChannelConnected(Guid correlationId, ulong topicEpoch)
     {
-        ProducerId = producerId;
-        ProducerName = producerName;
+        CorrelationId = correlationId;
+        TopicEpoch = topicEpoch;
     }
 
-    public ulong ProducerId { get; }
-    public string ProducerName { get; }
+    public Guid CorrelationId { get; }
+
+    public ulong TopicEpoch { get; }
 }

--- a/src/DotPulsar/Internal/NotReadyChannel.cs
+++ b/src/DotPulsar/Internal/NotReadyChannel.cs
@@ -34,8 +34,6 @@ public sealed class NotReadyChannel<TMessage> : IConsumerChannel<TMessage>, IPro
     public ValueTask<IMessage<TMessage>> Receive(CancellationToken cancellationToken = default)
         => throw GetException();
 
-    public ulong? TopicEpoch { get => null; }
-
     public Task Send(MessageMetadata metadata, ReadOnlySequence<byte> payload, TaskCompletionSource<BaseCommand> responseTcs, CancellationToken cancellationToken)
         => throw GetException();
 

--- a/src/DotPulsar/Internal/Producer.cs
+++ b/src/DotPulsar/Internal/Producer.cs
@@ -286,20 +286,6 @@ public sealed class Producer<TMessage> : IProducer<TMessage>, IRegisterEvent
     {
         ThrowIfDisposed();
 
-        // TODO: Do we want to have specific error messages on the exceptions here, or maybe a completely separate exception?
-        // TODO: Should we get the exception from the sub producer here somehow, or should we just remove this and let the Guard in the SubProducer handle it?
-        if (IsFinalState())
-            switch (_state.CurrentState)
-            {
-                case ProducerState.Fenced:
-                    throw new ProducerFencedException("Cannot produce to a fenced producer");
-                case ProducerState.Faulted:
-                    throw new ProducerFaultedException();
-                case ProducerState.Closed:
-                default:
-                    throw new ProducerClosedException();
-            }
-
         var autoAssignSequenceId = metadata.SequenceId == 0;
         if (autoAssignSequenceId)
             metadata.SequenceId = _sequenceId.FetchNext();

--- a/src/DotPulsar/Internal/ProducerChannel.cs
+++ b/src/DotPulsar/Internal/ProducerChannel.cs
@@ -31,15 +31,12 @@ public sealed class ProducerChannel : IProducerChannel
     private readonly ICompressorFactory? _compressorFactory;
     private readonly byte[]? _schemaVersion;
 
-    public ulong? TopicEpoch { get; }
-
     public ProducerChannel(
         ulong id,
         string name,
         IConnection connection,
         ICompressorFactory? compressorFactory,
-        byte[]? schemaVersion,
-        ulong topicEpoch)
+        byte[]? schemaVersion)
     {
         var sendPackagePolicy = new DefaultPooledObjectPolicy<SendPackage>();
         _sendPackagePool = new DefaultObjectPool<SendPackage>(sendPackagePolicy);
@@ -48,7 +45,6 @@ public sealed class ProducerChannel : IProducerChannel
         _connection = connection;
         _compressorFactory = compressorFactory;
         _schemaVersion = schemaVersion;
-        TopicEpoch = topicEpoch;
     }
 
     public async ValueTask ClosedByClient(CancellationToken cancellationToken)

--- a/src/DotPulsar/Internal/ProducerChannelFactory.cs
+++ b/src/DotPulsar/Internal/ProducerChannelFactory.cs
@@ -57,12 +57,19 @@ public sealed class ProducerChannelFactory : IProducerChannelFactory
 
     public async Task<IProducerChannel> Create(ulong? topicEpoch, CancellationToken cancellationToken)
     {
-        if (topicEpoch.HasValue) _commandProducer.TopicEpoch = topicEpoch.Value;
-        var connection = await _connectionPool.FindConnectionForTopic(_commandProducer.Topic, cancellationToken).ConfigureAwait(false);
-        var channel = new Channel(_correlationId, _eventRegister, new AsyncQueue<MessagePackage>());
-        var response = await connection.Send(_commandProducer, channel, cancellationToken).ConfigureAwait(false);
-        var schemaVersion = await GetSchemaVersion(connection, cancellationToken).ConfigureAwait(false);
-        return new ProducerChannel(response.ProducerId, response.ProducerName, connection, _compressorFactory, schemaVersion, response.TopicEpoch);
+        try
+        {
+            if (topicEpoch.HasValue) _commandProducer.TopicEpoch = topicEpoch.Value;
+            var connection = await _connectionPool.FindConnectionForTopic(_commandProducer.Topic, cancellationToken).ConfigureAwait(false);
+            var channel = new Channel(_correlationId, _eventRegister, new AsyncQueue<MessagePackage>());
+            var response = await connection.Send(_commandProducer, channel, cancellationToken).ConfigureAwait(false);
+            var schemaVersion = await GetSchemaVersion(connection, cancellationToken).ConfigureAwait(false);
+            return new ProducerChannel(response.ProducerId, response.ProducerName, connection, _compressorFactory, schemaVersion);
+        }
+        finally
+        {
+            _commandProducer.ResetTopicEpoch();
+        }
     }
 
     private async ValueTask<byte[]?> GetSchemaVersion(IConnection connection, CancellationToken cancellationToken)

--- a/src/DotPulsar/Internal/ProducerProcess.cs
+++ b/src/DotPulsar/Internal/ProducerProcess.cs
@@ -52,7 +52,9 @@ public sealed class ProducerProcess : Process
 
         if (ExecutorState == ExecutorState.Faulted)
         {
-            _stateManager.SetState(ProducerState.Faulted);
+            var formerState = _stateManager.SetState(ProducerState.Faulted);
+            if (formerState != ProducerState.Faulted)
+                _actionQueue.Enqueue(async _ => await _producer.ChannelFaulted(Exception!));
             return;
         }
 

--- a/src/DotPulsar/Internal/ProducerProcess.cs
+++ b/src/DotPulsar/Internal/ProducerProcess.cs
@@ -70,7 +70,7 @@ public sealed class ProducerProcess : Process
             case ChannelState.Connected:
                 _actionQueue.Enqueue(async x =>
                 {
-                    await _producer.ActivateChannel(x).ConfigureAwait(false);
+                    await _producer.ActivateChannel(TopicEpoch, x).ConfigureAwait(false);
                     _stateManager.SetState(ProducerState.Connected);
                 });
                 return;

--- a/src/DotPulsar/Internal/SubProducer.cs
+++ b/src/DotPulsar/Internal/SubProducer.cs
@@ -217,9 +217,9 @@ public sealed class SubProducer : IContainsProducerChannel, IState<ProducerState
         _channel = await _executor.Execute(() => _factory.Create(_topicEpoch, cancellationToken), cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task ActivateChannel(ulong topicEpoch, CancellationToken cancellationToken)
+    public async Task ActivateChannel(ulong? topicEpoch, CancellationToken cancellationToken)
     {
-        _topicEpoch = topicEpoch;
+        _topicEpoch ??= topicEpoch;
         _dispatcherCts = new CancellationTokenSource();
         await _executor.Execute(() =>
         {

--- a/src/DotPulsar/ProducerState.cs
+++ b/src/DotPulsar/ProducerState.cs
@@ -30,11 +30,6 @@ public enum ProducerState : byte
     Connected,
 
     /// <summary>
-    /// The producer is connected but waiting for exclusive access.
-    /// </summary>
-    WaitingForExclusive,
-
-    /// <summary>
     /// The producer is disconnected.
     /// </summary>
     Disconnected,
@@ -47,5 +42,15 @@ public enum ProducerState : byte
     /// <summary>
     /// Some of the sub-producers are disconnected.
     /// </summary>
-    PartiallyConnected
+    PartiallyConnected,
+
+    /// <summary>
+    /// The producer is connected but waiting for exclusive access.
+    /// </summary>
+    WaitingForExclusive,
+
+    /// <summary>
+    /// The producer has been fenced by the broker. This is a final state.
+    /// </summary>
+    Fenced
 }

--- a/tests/DotPulsar.Tests/ProducerTests.cs
+++ b/tests/DotPulsar.Tests/ProducerTests.cs
@@ -103,7 +103,7 @@ public class ProducerTests
 
     [Theory]
     [InlineData(ProducerAccessMode.Shared, ProducerState.Connected)]
-    [InlineData(ProducerAccessMode.Exclusive, ProducerState.Faulted)]
+    [InlineData(ProducerAccessMode.Exclusive, ProducerState.Fenced)]
     [InlineData(ProducerAccessMode.WaitForExclusive, ProducerState.WaitingForExclusive)]
     public async Task TwoProducers_WhenConnectingSecond_ThenGoToExpectedState(ProducerAccessMode accessMode, ProducerState expectedState)
     {
@@ -164,15 +164,15 @@ public class ProducerTests
             //Ignore
         }
 
-        var result = await producer1.OnStateChangeTo(ProducerState.Faulted, cts.Token);
+        var result = await producer1.OnStateChangeTo(ProducerState.Fenced, cts.Token);
 
         //Assert
-        result.Should().Be(ProducerState.Faulted);
+        result.Should().Be(ProducerState.Fenced);
     }
 
     [Theory]
     [InlineData(ProducerAccessMode.Exclusive, ProducerAccessMode.Shared, ProducerState.Connected, ProducerState.Disconnected)]
-    [InlineData(ProducerAccessMode.Shared, ProducerAccessMode.Exclusive, ProducerState.Connected, ProducerState.Faulted)]
+    [InlineData(ProducerAccessMode.Shared, ProducerAccessMode.Exclusive, ProducerState.Connected, ProducerState.Fenced)]
     [InlineData(ProducerAccessMode.Shared, ProducerAccessMode.WaitForExclusive, ProducerState.Connected, ProducerState.WaitingForExclusive)]
     [InlineData(ProducerAccessMode.Exclusive, ProducerAccessMode.WaitForExclusive, ProducerState.Connected, ProducerState.WaitingForExclusive)]
 


### PR DESCRIPTION
Fixes issues with Producer access modes

# Description

Fixes disconnect issues related to producer access modes.
Also changed behavior to to align with java client. When a producer with WaitForExclusive mode has been given 
exclusive access it cannot go back to WaitForExclusive, and will instead be fenced.

# Regression

Issue introduced in unreleased code

# Testing

Manual testing with TCP connection killing
