### PR TITLE
Reader faulted issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Support for consuming partitioned topics
 
+### Fixed
+
+- Fixed issue preventing reader to correctly go into `Faulted` state.
+
 ## [2.12.0] - ?
 
 ### Added

--- a/src/DotPulsar/Internal/ReaderProcess.cs
+++ b/src/DotPulsar/Internal/ReaderProcess.cs
@@ -47,7 +47,6 @@ public sealed class ReaderProcess : Process
 
         if (ExecutorState == ExecutorState.Faulted)
         {
-            _stateManager.SetState(ReaderState.Faulted);
             var formerState = _stateManager.SetState(ReaderState.Faulted);
             if (formerState != ReaderState.Faulted)
                 ActionQueue.Enqueue(async _ => await _reader.ChannelFaulted(Exception!) );


### PR DESCRIPTION
Fixes Reader faulted issue

# Description

SetState unintentionally called twice resulting in reader channel not being faulted
