### PR TITLE
Partitioned topic support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
 
+- Added Partitioned topic support for the Consumer and Reader
+- MessageId now includes an extra field for setting the topic
 - Support for `ProducerAccessMode` to prevent multiple producers on a single topic
 - A new `Fenced` state for producers which is a final state
 - The ability to explicitly set compression information on an outgoing message using `MessageMetadata`
@@ -17,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Issue preventing readers from correctly going into the `Faulted` state
 - Calling `await Send(...)` on a producer did not correctly terminate with an exception when a send operation failed (e.g. because the producer faulted)
 - The 'Partition' in 'MessageId' will now be set to the correct partition when producing to partitioned topics
+
+### Deprecated
+
+- GetLastMessageId of the Consumer and Reader is deprecated, and soon to be removed. Please use GetLastMessageIds instead.
 
 ## [2.11.1] - 2023-07-05
 

--- a/src/DotPulsar/Abstractions/IConsumer.cs
+++ b/src/DotPulsar/Abstractions/IConsumer.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 /// <summary>
 /// A consumer abstraction.
 /// </summary>
-public interface IConsumer : IGetLastMessageId, ISeek, IState<ConsumerState>, IAsyncDisposable
+public interface IConsumer : IGetLastMessageId, IGetLastMessageIds, ISeek, IState<ConsumerState>, IAsyncDisposable
 {
     /// <summary>
     /// Acknowledge the consumption of a single message using the MessageId.

--- a/src/DotPulsar/Abstractions/IGetLastMessageId.cs
+++ b/src/DotPulsar/Abstractions/IGetLastMessageId.cs
@@ -14,6 +14,7 @@
 
 namespace DotPulsar.Abstractions;
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,5 +26,6 @@ public interface IGetLastMessageId
     /// <summary>
     /// Get the MessageId of the last message on the topic.
     /// </summary>
+    [Obsolete("GetLastMessageId is obsolete. Please use GetLastMessageIds instead.")]
     ValueTask<MessageId> GetLastMessageId(CancellationToken cancellationToken = default);
 }

--- a/src/DotPulsar/Abstractions/IGetLastMessageIds.cs
+++ b/src/DotPulsar/Abstractions/IGetLastMessageIds.cs
@@ -12,15 +12,20 @@
  * limitations under the License.
  */
 
-namespace DotPulsar.Internal.Abstractions;
+namespace DotPulsar.Abstractions;
 
-using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-public interface IConnectionPool : IAsyncDisposable
+/// <summary>
+/// An abstraction for getting the last message ids.
+/// </summary>
+public interface IGetLastMessageIds
 {
-    ValueTask<IConnection> FindConnectionForTopic(string topic, CancellationToken cancellationToken = default);
-
-    ValueTask<uint> GetNumberOfPartitions(String topic, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Provides the latest message ID for all the topic(s).
+    /// </summary>
+    /// <returns>List of MessageId from all the topic(s)</returns>
+    ValueTask<IEnumerable<MessageId>> GetLastMessageIds(CancellationToken cancellationToken = default);
 }

--- a/src/DotPulsar/Abstractions/IReader.cs
+++ b/src/DotPulsar/Abstractions/IReader.cs
@@ -19,7 +19,7 @@ using System;
 /// <summary>
 /// A reader abstraction.
 /// </summary>
-public interface IReader : IGetLastMessageId, ISeek, IState<ReaderState>, IAsyncDisposable
+public interface IReader : IGetLastMessageId, IGetLastMessageIds, ISeek, IState<ReaderState>, IAsyncDisposable
 {
     /// <summary>
     /// The reader's service url.

--- a/src/DotPulsar/DotPulsar.csproj
+++ b/src/DotPulsar/DotPulsar.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="HashDepot" Version="2.0.3" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.8" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.10" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="protobuf-net" Version="3.2.26" />
     <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />

--- a/src/DotPulsar/Internal/ConsumerChannelFactory.cs
+++ b/src/DotPulsar/Internal/ConsumerChannelFactory.cs
@@ -31,6 +31,7 @@ public sealed class ConsumerChannelFactory<TMessage> : IConsumerChannelFactory<T
     private readonly BatchHandler<TMessage> _batchHandler;
     private readonly IMessageFactory<TMessage> _messageFactory;
     private readonly IEnumerable<IDecompressorFactory> _decompressorFactories;
+    private readonly string _topic;
 
     public ConsumerChannelFactory(
         Guid correlationId,
@@ -40,7 +41,8 @@ public sealed class ConsumerChannelFactory<TMessage> : IConsumerChannelFactory<T
         uint messagePrefetchCount,
         BatchHandler<TMessage> batchHandler,
         IMessageFactory<TMessage> messageFactory,
-        IEnumerable<IDecompressorFactory> decompressorFactories)
+        IEnumerable<IDecompressorFactory> decompressorFactories,
+        string topic)
     {
         _correlationId = correlationId;
         _eventRegister = eventRegister;
@@ -50,6 +52,7 @@ public sealed class ConsumerChannelFactory<TMessage> : IConsumerChannelFactory<T
         _batchHandler = batchHandler;
         _messageFactory = messageFactory;
         _decompressorFactories = decompressorFactories;
+        _topic = topic;
     }
 
     public async Task<IConsumerChannel<TMessage>> Create(CancellationToken cancellationToken)
@@ -58,6 +61,6 @@ public sealed class ConsumerChannelFactory<TMessage> : IConsumerChannelFactory<T
         var messageQueue = new AsyncQueue<MessagePackage>();
         var channel = new Channel(_correlationId, _eventRegister, messageQueue);
         var response = await connection.Send(_subscribe, channel, cancellationToken).ConfigureAwait(false);
-        return new ConsumerChannel<TMessage>(response.ConsumerId, _messagePrefetchCount, messageQueue, connection, _batchHandler, _messageFactory, _decompressorFactories);
+        return new ConsumerChannel<TMessage>(response.ConsumerId, _messagePrefetchCount, messageQueue, connection, _batchHandler, _messageFactory, _decompressorFactories, _topic);
     }
 }

--- a/src/DotPulsar/Internal/Extensions/MessageIdDataExtensions.cs
+++ b/src/DotPulsar/Internal/Extensions/MessageIdDataExtensions.cs
@@ -18,8 +18,8 @@ using DotPulsar.Internal.PulsarApi;
 
 public static class MessageIdDataExtensions
 {
-    public static MessageId ToMessageId(this MessageIdData messageIdData)
-        => new(messageIdData.LedgerId, messageIdData.EntryId, messageIdData.Partition, messageIdData.BatchIndex);
+    public static MessageId ToMessageId(this MessageIdData messageIdData, string topic)
+        => new(messageIdData.LedgerId, messageIdData.EntryId, messageIdData.Partition, messageIdData.BatchIndex, topic);
 
     public static void MapFrom(this MessageIdData destination, MessageId source)
     {

--- a/src/DotPulsar/Internal/SubConsumer.cs
+++ b/src/DotPulsar/Internal/SubConsumer.cs
@@ -1,0 +1,227 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DotPulsar.Internal;
+
+using DotPulsar.Abstractions;
+using DotPulsar.Exceptions;
+using DotPulsar.Internal.Abstractions;
+using DotPulsar.Internal.Events;
+using DotPulsar.Internal.Extensions;
+using DotPulsar.Internal.PulsarApi;
+using Microsoft.Extensions.ObjectPool;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+public sealed class SubConsumer<TMessage> : IConsumer<TMessage>, IContainsChannel
+{
+    private readonly Guid _correlationId;
+    private readonly IRegisterEvent _eventRegister;
+    private IConsumerChannel<TMessage> _channel;
+    private readonly ObjectPool<CommandAck> _commandAckPool;
+    private readonly IExecute _executor;
+    private readonly IStateChanged<ConsumerState> _state;
+    private readonly IConsumerChannelFactory<TMessage> _factory;
+    private int _isDisposed;
+    private Exception? _faultException;
+
+    public Uri ServiceUrl { get; }
+    public string SubscriptionName { get; }
+    public string Topic { get; }
+
+    public SubConsumer(
+        Guid correlationId,
+        Uri serviceUrl,
+        string subscriptionName,
+        string topic,
+        IRegisterEvent eventRegister,
+        IConsumerChannel<TMessage> initialChannel,
+        IExecute executor,
+        IStateChanged<ConsumerState> state,
+        IConsumerChannelFactory<TMessage> factory)
+    {
+        _correlationId = correlationId;
+        ServiceUrl = serviceUrl;
+        SubscriptionName = subscriptionName;
+        Topic = topic;
+        _eventRegister = eventRegister;
+        _channel = initialChannel;
+        _executor = executor;
+        _state = state;
+        _factory = factory;
+        _commandAckPool = new DefaultObjectPool<CommandAck>(new DefaultPooledObjectPolicy<CommandAck>());
+        _isDisposed = 0;
+
+        _eventRegister.Register(new ConsumerCreated(_correlationId));
+    }
+
+    public async ValueTask<ConsumerState> OnStateChangeTo(ConsumerState state, CancellationToken cancellationToken)
+        => await _state.StateChangedTo(state, cancellationToken).ConfigureAwait(false);
+
+    public async ValueTask<ConsumerState> OnStateChangeFrom(ConsumerState state, CancellationToken cancellationToken)
+        => await _state.StateChangedFrom(state, cancellationToken).ConfigureAwait(false);
+
+    public bool IsFinalState()
+        => _state.IsFinalState();
+
+    public bool IsFinalState(ConsumerState state)
+        => _state.IsFinalState(state);
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+            return;
+
+        _eventRegister.Register(new ProducerDisposed(_correlationId));
+        await DisposeChannel().ConfigureAwait(false);
+    }
+
+    private async ValueTask DisposeChannel()
+    {
+        await _channel.ClosedByClient(CancellationToken.None).ConfigureAwait(false);
+        await _channel.DisposeAsync().ConfigureAwait(false);
+    }
+
+    public async ValueTask<IMessage<TMessage>> Receive(CancellationToken cancellationToken)
+        => await _executor.Execute(() => InternalReceive(cancellationToken), cancellationToken).ConfigureAwait(false);
+
+    public async ValueTask Acknowledge(MessageId messageId, CancellationToken cancellationToken)
+        => await InternalAcknowledge(messageId, CommandAck.AckType.Individual, cancellationToken).ConfigureAwait(false);
+
+    public async ValueTask AcknowledgeCumulative(MessageId messageId, CancellationToken cancellationToken)
+        => await InternalAcknowledge(messageId, CommandAck.AckType.Cumulative, cancellationToken).ConfigureAwait(false);
+
+    public async ValueTask RedeliverUnacknowledgedMessages(IEnumerable<MessageId> messageIds, CancellationToken cancellationToken)
+    {
+        var command = new CommandRedeliverUnacknowledgedMessages();
+        command.MessageIds.AddRange(messageIds.Select(messageId => messageId.ToMessageIdData()));
+        await _executor.Execute(() => InternalRedeliverUnacknowledgedMessages(command, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask RedeliverUnacknowledgedMessages(CancellationToken cancellationToken)
+        => await RedeliverUnacknowledgedMessages(Enumerable.Empty<MessageId>(), cancellationToken).ConfigureAwait(false);
+
+    public async ValueTask Unsubscribe(CancellationToken cancellationToken)
+    {
+        var unsubscribe = new CommandUnsubscribe();
+        await _executor.Execute(() => InternalUnsubscribe(unsubscribe, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask Seek(MessageId messageId, CancellationToken cancellationToken)
+    {
+        var seek = new CommandSeek { MessageId = messageId.ToMessageIdData() };
+        await _executor.Execute(() => InternalSeek(seek, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask Seek(ulong publishTime, CancellationToken cancellationToken)
+    {
+        var seek = new CommandSeek { MessagePublishTime = publishTime };
+        await _executor.Execute(() => InternalSeek(seek, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<MessageId> GetLastMessageId(CancellationToken cancellationToken)
+    {
+        var getLastMessageId = new CommandGetLastMessageId();
+        return await _executor.Execute(() => InternalGetLastMessageId(getLastMessageId, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    private void Guard()
+    {
+        if (_isDisposed != 0)
+            throw new ConsumerDisposedException(GetType().FullName!);
+
+        if (_faultException is not null)
+            throw new ConsumerFaultedException(_faultException);
+    }
+
+    public async Task EstablishNewChannel(CancellationToken cancellationToken)
+    {
+        var channel = await _executor.Execute(() => _factory.Create(cancellationToken), cancellationToken).ConfigureAwait(false);
+
+        var oldChannel = _channel;
+        if (oldChannel is not null)
+            await oldChannel.DisposeAsync().ConfigureAwait(false);
+
+        _channel = channel;
+    }
+
+    public async ValueTask CloseChannel(CancellationToken cancellationToken)
+        => await _channel.ClosedByClient(cancellationToken).ConfigureAwait(false);
+
+    public async ValueTask ChannelFaulted(Exception exception)
+    {
+        _faultException = exception;
+        await DisposeChannel().ConfigureAwait(false);
+    }
+
+    private async ValueTask InternalAcknowledge(CommandAck command, CancellationToken cancellationToken)
+    {
+        Guard();
+        await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask InternalRedeliverUnacknowledgedMessages(CommandRedeliverUnacknowledgedMessages command, CancellationToken cancellationToken)
+    {
+        Guard();
+        await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<MessageId> InternalGetLastMessageId(CommandGetLastMessageId command, CancellationToken cancellationToken)
+    {
+        Guard();
+        return await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task InternalSeek(CommandSeek command, CancellationToken cancellationToken)
+    {
+        Guard();
+        await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<IMessage<TMessage>> InternalReceive(CancellationToken cancellationToken)
+    {
+        Guard();
+        return await _channel.Receive(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask InternalUnsubscribe(CommandUnsubscribe command, CancellationToken cancellationToken)
+    {
+        Guard();
+        await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask InternalAcknowledge(MessageId messageId, CommandAck.AckType ackType, CancellationToken cancellationToken)
+    {
+        var commandAck = _commandAckPool.Get();
+        commandAck.Type = ackType;
+        if (commandAck.MessageIds.Count == 0)
+            commandAck.MessageIds.Add(messageId.ToMessageIdData());
+        else
+            commandAck.MessageIds[0].MapFrom(messageId);
+
+        try
+        {
+            await _executor.Execute(() => InternalAcknowledge(commandAck, cancellationToken), cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _commandAckPool.Return(commandAck);
+        }
+    }
+    public ValueTask<IEnumerable<MessageId>> GetLastMessageIds(CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException();
+}

--- a/src/DotPulsar/Internal/SubReader.cs
+++ b/src/DotPulsar/Internal/SubReader.cs
@@ -1,0 +1,161 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DotPulsar.Internal;
+
+using DotPulsar.Abstractions;
+using DotPulsar.Exceptions;
+using DotPulsar.Internal.Abstractions;
+using DotPulsar.Internal.Events;
+using DotPulsar.Internal.PulsarApi;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public sealed class SubReader<TMessage> : IContainsChannel, IReader<TMessage>
+{
+    private readonly Guid _correlationId;
+    private readonly IRegisterEvent _eventRegister;
+    private IConsumerChannel<TMessage> _channel;
+    private readonly IExecute _executor;
+    private readonly IStateChanged<ReaderState> _state;
+    private readonly IConsumerChannelFactory<TMessage> _factory;
+    private int _isDisposed;
+    private Exception? _faultException;
+
+    public Uri ServiceUrl { get; }
+    public string Topic { get; }
+
+    public SubReader(
+        Guid correlationId,
+        Uri serviceUrl,
+        string topic,
+        IRegisterEvent eventRegister,
+        IConsumerChannel<TMessage> initialChannel,
+        IExecute executor,
+        IStateChanged<ReaderState> state,
+        IConsumerChannelFactory<TMessage> factory)
+    {
+        _correlationId = correlationId;
+        ServiceUrl = serviceUrl;
+        Topic = topic;
+        _eventRegister = eventRegister;
+        _channel = initialChannel;
+        _executor = executor;
+        _state = state;
+        _factory = factory;
+        _isDisposed = 0;
+
+        _eventRegister.Register(new ReaderCreated(_correlationId));
+    }
+
+    public async ValueTask<ReaderState> OnStateChangeTo(ReaderState state, CancellationToken cancellationToken)
+        => await _state.StateChangedTo(state, cancellationToken).ConfigureAwait(false);
+
+    public async ValueTask<ReaderState> OnStateChangeFrom(ReaderState state, CancellationToken cancellationToken)
+        => await _state.StateChangedFrom(state, cancellationToken).ConfigureAwait(false);
+
+    public bool IsFinalState()
+        => _state.IsFinalState();
+
+    public bool IsFinalState(ReaderState state)
+        => _state.IsFinalState(state);
+
+    public async ValueTask<MessageId> GetLastMessageId(CancellationToken cancellationToken)
+    {
+        var getLastMessageId = new CommandGetLastMessageId();
+        return await _executor.Execute(() => InternalGetLastMessageId(getLastMessageId, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<MessageId> InternalGetLastMessageId(CommandGetLastMessageId command, CancellationToken cancellationToken)
+    {
+        Guard();
+        var messageId = await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+        return new MessageId(messageId.LedgerId, messageId.EntryId, messageId.Partition, messageId.BatchIndex, Topic);
+    }
+
+    public async ValueTask<IMessage<TMessage>> Receive(CancellationToken cancellationToken)
+        => await _executor.Execute(() => InternalReceive(cancellationToken), cancellationToken).ConfigureAwait(false);
+
+    private async ValueTask<IMessage<TMessage>> InternalReceive(CancellationToken cancellationToken)
+    {
+        Guard();
+        return await _channel.Receive(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask Seek(MessageId messageId, CancellationToken cancellationToken)
+    {
+        var seek = new CommandSeek { MessageId = messageId.ToMessageIdData() };
+        await _executor.Execute(() => InternalSeek(seek, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask Seek(ulong publishTime, CancellationToken cancellationToken)
+    {
+        var seek = new CommandSeek { MessagePublishTime = publishTime };
+        await _executor.Execute(() => InternalSeek(seek, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+            return;
+
+        _eventRegister.Register(new ReaderDisposed(_correlationId));
+        await DisposeChannel().ConfigureAwait(false);
+    }
+
+    private async ValueTask DisposeChannel()
+    {
+        await _channel.ClosedByClient(CancellationToken.None).ConfigureAwait(false);
+        await _channel.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private async Task InternalSeek(CommandSeek command, CancellationToken cancellationToken)
+    {
+        Guard();
+        await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task EstablishNewChannel(CancellationToken cancellationToken)
+    {
+        var channel = await _executor.Execute(() => _factory.Create(cancellationToken), cancellationToken).ConfigureAwait(false);
+
+        var oldChannel = _channel;
+        if (oldChannel is not null)
+            await oldChannel.DisposeAsync().ConfigureAwait(false);
+
+        _channel = channel;
+    }
+
+    public async ValueTask CloseChannel(CancellationToken cancellationToken)
+        => await _channel.ClosedByClient(cancellationToken).ConfigureAwait(false);
+
+    private void Guard()
+    {
+        if (_isDisposed != 0)
+            throw new ReaderDisposedException(GetType().FullName!);
+
+        if (_faultException is not null)
+            throw new ReaderFaultedException(_faultException);
+    }
+
+    public async ValueTask ChannelFaulted(Exception exception)
+    {
+        _faultException = exception;
+        await DisposeChannel().ConfigureAwait(false);
+    }
+    public ValueTask<IEnumerable<MessageId>> GetLastMessageIds(CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException();
+}

--- a/src/DotPulsar/MessageId.cs
+++ b/src/DotPulsar/MessageId.cs
@@ -42,12 +42,13 @@ public sealed class MessageId : IEquatable<MessageId>, IComparable<MessageId>
     /// <summary>
     /// Initializes a new instance using the specified ledgerId, entryId, partition and batchIndex.
     /// </summary>
-    public MessageId(ulong ledgerId, ulong entryId, int partition, int batchIndex)
+    public MessageId(ulong ledgerId, ulong entryId, int partition, int batchIndex, string topic = "")
     {
         LedgerId = ledgerId;
         EntryId = entryId;
         Partition = partition;
         BatchIndex = batchIndex;
+        Topic = topic;
     }
 
     /// <summary>
@@ -70,6 +71,11 @@ public sealed class MessageId : IEquatable<MessageId>, IComparable<MessageId>
     /// </summary>
     public int BatchIndex { get; }
 
+    /// <summary>
+    /// Return the full topic name of a message.
+    /// </summary>
+    public string Topic { get; }
+
     public int CompareTo(MessageId? other)
     {
         if (other is null)
@@ -84,6 +90,10 @@ public sealed class MessageId : IEquatable<MessageId>, IComparable<MessageId>
             return result;
 
         result = Partition.CompareTo(other.Partition);
+        if (result != 0)
+            return result;
+
+        result = String.Compare(Topic, other.Topic, StringComparison.Ordinal);
         if (result != 0)
             return result;
 
@@ -106,7 +116,7 @@ public sealed class MessageId : IEquatable<MessageId>, IComparable<MessageId>
         => o is MessageId id && Equals(id);
 
     public bool Equals(MessageId? other)
-        => other is not null && LedgerId == other.LedgerId && EntryId == other.EntryId && Partition == other.Partition && BatchIndex == other.BatchIndex;
+        => other is not null && LedgerId == other.LedgerId && EntryId == other.EntryId && Partition == other.Partition && BatchIndex == other.BatchIndex && Topic == other.Topic;
 
     public static bool operator ==(MessageId x, MessageId y)
         => ReferenceEquals(x, y) || (x is not null && x.Equals(y));
@@ -115,10 +125,14 @@ public sealed class MessageId : IEquatable<MessageId>, IComparable<MessageId>
         => !(x == y);
 
     public override int GetHashCode()
-        => HashCode.Combine(LedgerId, EntryId, Partition, BatchIndex);
+        => HashCode.Combine(LedgerId, EntryId, Partition, BatchIndex, Topic);
 
     public override string ToString()
-        => $"{LedgerId}:{EntryId}:{Partition}:{BatchIndex}";
+    {
+        if (Topic == string.Empty)
+            return $"{LedgerId}:{EntryId}:{Partition}:{BatchIndex}";
+        return $"{LedgerId}:{EntryId}:{Partition}:{BatchIndex}:{Topic}";
+    }
 
     internal MessageIdData ToMessageIdData()
     {

--- a/tests/DotPulsar.Tests/DotPulsar.Tests.csproj
+++ b/tests/DotPulsar.Tests/DotPulsar.Tests.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="IronSnappy" Version="1.3.1" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.5" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DotPulsar.Tests/MessageIdTests.cs
+++ b/tests/DotPulsar.Tests/MessageIdTests.cs
@@ -36,6 +36,19 @@ public class MessageIdTests
     }
 
     [Fact]
+    public void CompareTo_GivenTheSameValuesWithTopic_ShouldBeEqual()
+    {
+        var m1 = new MessageId(1, 2, 3, 4, "persistent://public/default/my-topic-partition-0");
+        var m2 = new MessageId(1, 2, 3, 4, "persistent://public/default/my-topic-partition-0");
+
+        m1.CompareTo(m2).Should().Be(0);
+        (m1 < m2).Should().BeFalse();
+        (m1 > m2).Should().BeFalse();
+        (m1 >= m2).Should().BeTrue();
+        (m1 <= m2).Should().BeTrue();
+    }
+
+    [Fact]
     public void CompareTo_GivenAllNull_ShouldBeEqual()
     {
         MessageId m1 = null;
@@ -117,6 +130,17 @@ public class MessageIdTests
         (m1 != m2).Should().BeFalse();
     }
 
+    [Fact]
+    public void Equals_GivenTheSameValuesWithTopic_ShouldBeEqual()
+    {
+        var m1 = new MessageId(1, 2, 3, 4, "persistent://public/default/my-topic-partition-0");
+        var m2 = new MessageId(1, 2, 3, 4, "persistent://public/default/my-topic-partition-0");
+
+        m1.Equals(m2).Should().BeTrue();
+        (m1 == m2).Should().BeTrue();
+        (m1 != m2).Should().BeFalse();
+    }
+
     [Theory]
     [InlineData(0, 2, 3, 4)] // LegerId not the same
     [InlineData(1, 0, 3, 4)] // EntryId not the same
@@ -126,6 +150,22 @@ public class MessageIdTests
     {
         var m1 = new MessageId(ledgerId, entryId, partition, batchIndex);
         var m2 = new MessageId(1, 2, 3, 4);
+
+        m1.Equals(m2).Should().BeFalse();
+        (m1 == m2).Should().BeFalse();
+        (m1 != m2).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0, 2, 3, 4, "persistent://public/default/my-topic-partition-1")] // LegerId not the same
+    [InlineData(1, 0, 3, 4, "persistent://public/default/my-topic-partition-1")] // EntryId not the same
+    [InlineData(1, 2, 0, 4, "persistent://public/default/my-topic-partition-1")] // Partition not the same
+    [InlineData(1, 2, 3, 0, "persistent://public/default/my-topic-partition-1")] // BatchIndex not the same
+    [InlineData(1, 2, 3, 4, "persistent://public/default/my-topic-partition-0")] // Topic not the same
+    public void Equals_GivenDifferentValuesWithTopic_ShouldNotBeEqual(ulong ledgerId, ulong entryId, int partition, int batchIndex, string topic)
+    {
+        var m1 = new MessageId(ledgerId, entryId, partition, batchIndex, topic);
+        var m2 = new MessageId(1, 2, 3, 4, "persistent://public/default/my-topic-partition-1");
 
         m1.Equals(m2).Should().BeFalse();
         (m1 == m2).Should().BeFalse();

--- a/tests/DotPulsar.Tests/ReaderTests.cs
+++ b/tests/DotPulsar.Tests/ReaderTests.cs
@@ -1,0 +1,223 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DotPulsar.Tests;
+
+using DotPulsar.Abstractions;
+using DotPulsar.Extensions;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+[Collection("Integration"), Trait("Category", "Integration")]
+public class ReaderTests
+{
+    private readonly IntegrationFixture _fixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public ReaderTests(IntegrationFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async Task GetLastMessageId_GivenNonPartitionedTopic_ShouldGetMessageId()
+    {
+        //Arrange
+        const string topicName = "persistent://public/default/reader-non-partitioned-topic-get-last-MessageId";
+        const string content = "test-message";
+        const int numberOfMessages = 6;
+
+        await using var client = CreateClient();
+        await using var reader = CreateReader(client, MessageId.Earliest, topicName);
+        await using var producer = CreateProducer(client, topicName);
+
+        MessageId expected = null!;
+        for (var i = 0; i < numberOfMessages; i++)
+        {
+            var messageId = await producer.Send(content);
+            if (i >= 5)
+            {
+                expected = messageId;
+            }
+        }
+
+        //Act
+        var actual = await reader.GetLastMessageId();
+
+        //Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task GetLastMessageId_GivenPartitionedTopic_ShouldThrowException()
+    {
+        //Arrange
+        const string topicName = "persistent://public/default/reader-partitioned-topic-get-last-MessageId";
+        const int partitions = 3;
+        _fixture.CreatePartitionedTopic(topicName, partitions);
+
+        await using var client = CreateClient();
+        await using var reader = CreateReader(client, MessageId.Earliest, topicName);
+
+        //Act
+        var exception = await Record.ExceptionAsync(() => reader.GetLastMessageId().AsTask());
+
+        //Assert
+        exception.Should().BeOfType<NotSupportedException>();
+    }
+
+    [Fact]
+    public async Task GetLastMessageIds_GivenNonPartitionedTopic_ShouldGetMessageIdFromPartition()
+    {
+        //Arrange
+        const string topicName = "reader-non-partitioned-topic-get-last-MessageIds";
+        const string content = "test-message";
+        const int numberOfMessages = 6;
+
+        await using var client = CreateClient();
+        await using var reader = CreateReader(client, MessageId.Earliest, topicName);
+        await using var producer = CreateProducer(client, topicName);
+
+        var expected = new List<MessageId>();
+        for (var i = 0; i < numberOfMessages; i++)
+        {
+            var messageId = await producer.Send(content);
+            if (i >= 5)
+            {
+                expected.Add(messageId);
+            }
+        }
+        //Act
+        var actual = await reader.GetLastMessageIds();
+
+        //Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task GetLastMessageIds_GivenPartitionedTopic_ShouldGetMessageIdsFromPartitions()
+    {
+        //Arrange
+        const string topicName = "reader-partitioned-topic-get-last-MessageIds";
+        const string content = "test-message";
+        const int numberOfMessages = 6;
+        const int partitions = 3;
+        _fixture.CreatePartitionedTopic($"persistent://public/default/{topicName}", partitions);
+
+        await using var client = CreateClient();
+        await using var reader = CreateReader(client, MessageId.Earliest, topicName);
+        await using var producer = CreateProducer(client, topicName);
+
+        var expected = new List<MessageId>();
+        for (var i = 0; i < numberOfMessages; i++)
+        {
+            var messageId = await producer.Send(content);
+            if (i >= 3)
+            {
+                expected.Add(messageId);
+            }
+        }
+
+        //Act
+        var actual = await reader.GetLastMessageIds();
+
+        //Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task Receive_GivenNonPartitionedTopic_ShouldReceiveAll()
+    {
+        //Arrange
+        const string topicName = "Receive_GivenNonPartitionedTopicWithMessages_ShouldReceiveAll";
+        const int numberOfMessages = 10;
+
+        await using var client = CreateClient();
+        await using var producer = CreateProducer(client, topicName);
+        await using var reader = CreateReader(client, MessageId.Earliest, topicName);
+
+        var expected = new List<MessageId>();
+        for (var i = 0; i < numberOfMessages; i++)
+        {
+            var messageId = await producer.Send("test-message");
+            expected.Add(messageId);
+        }
+
+        //Act
+        var actual = new List<MessageId>();
+        for (var i = 0; i < numberOfMessages; i++)
+        {
+            var messageId = await reader.Receive();
+            actual.Add(messageId.MessageId);
+        }
+
+        //Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task Receive_GivenPartitionedTopic_ShouldReceiveAll()
+    {
+        //Arrange
+        const string topicName = "reader-with-3-partitions-test";
+        const int numberOfMessages = 50;
+        const int partitions = 3;
+        _fixture.CreatePartitionedTopic($"persistent://public/default/{topicName}", partitions);
+
+        await using var client = CreateClient();
+        await using var producer = CreateProducer(client, topicName);
+        await using var reader = CreateReader(client, MessageId.Earliest, topicName);
+
+        var expected = new List<MessageId>();
+        for (var i = 0; i < numberOfMessages; i++)
+        {
+            var messageId = await producer.Send("test-message");
+            expected.Add(messageId);
+        }
+
+        //Act
+        var actual = new List<MessageId>();
+        for (var i = 0; i < numberOfMessages; i++)
+        {
+            var messageId = await reader.Receive();
+            actual.Add(messageId.MessageId);
+        }
+
+        //Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    private IProducer<String> CreateProducer(IPulsarClient pulsarClient, string topicName) => pulsarClient.NewProducer(Schema.String)
+        .Topic(topicName)
+        .Create();
+
+    private IReader<String> CreateReader(IPulsarClient pulsarClient, MessageId messageId, string topicName) => pulsarClient.NewReader(Schema.String)
+        .StartMessageId(messageId)
+        .Topic(topicName)
+        .Create();
+
+    private IPulsarClient CreateClient()
+        => PulsarClient
+            .Builder()
+            .Authentication(AuthenticationFactory.Token(ct => ValueTask.FromResult(_fixture.CreateToken(Timeout.InfiniteTimeSpan))))
+            .ExceptionHandler(ec => _testOutputHelper.WriteLine($"Exception: {ec.Exception}"))
+            .ServiceUrl(_fixture.ServiceUrl)
+            .Build();
+}


### PR DESCRIPTION
# Description
This PR adds partitioned topic support for the Consumer and Reader in DotPulsar.

Should you choose to accept this PR. I believe it will also pave the way for implementing multi-topic subscriptions https://github.com/apache/pulsar-dotpulsar/issues/5, later.

Major changes
The Consumer class is refactored, so its responsibility is to keep track of SubConsumers. Therefore, it is now the new SubConsumer class that has the actual obligation to consume on a topic. With this design change, the Consumer
now has the much-requested partitioned topic support. The Reader was also reworked to add partitioned topic support. The reader class keeps track of SubReaders, just like the Consumer class.

Implemented GetLastMessageIds in the Consumer and Reader. Therefore, in order to facilitate the use of the getLastMessageIds method for both the Reader and the Consumer, the MessageId class now includes an extra field for setting the topic.

The Consumer Reader and Producer now always sets the topic field on the MessageId(s) it returns.

Code smell fixes
Both the Producer and the Consumer classes had the method GetNumberOfPartitions with the same code. This is a duplicated code smell. It is fixed By moving the logic into the ConnectionPool.

Deprecated
GetLastMessageId is deprecated, please use GetLastMessageIds.

Tests in ReaderTests.cs and ConsumerTests.cs are renamed to follow the MethodName_[Given/When]StateUnderTest_[Then/Should]ExpectedBehavior naming convention.

Added renamed or added tests in ConsumerTests.cs
GetLastMessageId_GivenNonPartitionedTopic_ShouldGetMessageIdFromPartition
GetLastMessageId_GivenPartitionedTopic_ShouldThrowException
GetLastMessageIds_GivenNonPartitionedTopic_ShouldGetMessageIdFromPartition
GetLastMessageIds_GivenPartitionedTopic_ShouldGetMessageIdFromAllPartitions
Receive_GivenNonPartitionedTopic_ShouldReceiveAll
Receive_GivenPartitionedTopic_ShouldReceiveAll

Added renamed or added tests in ReaderTests.cs
GetLastMessageId_GivenNonPartitionedTopic_ShouldGetMessageId
GetLastMessageId_GivenPartitionedTopic_ShouldThrowException
GetLastMessageIds_GivenNonPartitionedTopic_ShouldGetMessageIdFromPartition
GetLastMessageIds_GivenPartitionedTopic_ShouldGetMessageIdsFromPartitions
Receive_GivenNonPartitionedTopic_ShouldReceiveAll
Receive_GivenPartitionedTopic_ShouldReceiveAll

Added two tests to ProducerTests.cs
When sending to a multi-partition topic, MessageId.partition it should not only be -1.
When sending to a topic with a single partition, MessageId.partition it should be -1.

Added test MessageIdTests.cs
CompareTo_GivenTheSameValuesWithTopic_ShouldBeEqual
Equals_GivenTheSameValuesWithTopic_ShouldBeEqual
Equals_GivenDifferentValuesWithTopic_ShouldNotBeEqual

Updated dependencies
Microsoft.Extensions.ObjectPool from version 7.0.8 to 7.0.10
Microsoft.NET.Test.Sdk from version 17.6.3 to 1.7.0
xunit from version 2.4.2 to 2.5.0
xunit.runner.visualstudio from version 2.4.2 to 2.5.0

If Merged:
Close PR https://github.com/apache/pulsar-dotpulsar/pull/49
Close PR https://github.com/apache/pulsar-dotpulsar/pull/81
Close Issue https://github.com/apache/pulsar-dotpulsar/issues/141

# Testing

dotnet test passed

## Acknowledgments
Thanks to @blankensteiner for helping with questions and suggestions for this PR 😄