### PR TITLE
Feature/object pooling issue (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1] - 2023-07-05
+
+### Fixed
+
+- Fixed issue with `Send` extension methods that do include `MessageMetadata` in the parameter list. The issue prevents more than two messages from being published on namespaces where deduplication is enabled.
+
 ## [2.11.0] - 2023-03-13
 
 ### Added

--- a/src/DotPulsar/Extensions/SendChannelExtensions.cs
+++ b/src/DotPulsar/Extensions/SendChannelExtensions.cs
@@ -67,6 +67,7 @@ public static class SendChannelExtensions
 
         async ValueTask ReleaseMetadataAndCallCallback(MessageId id)
         {
+            metadata.Metadata.SequenceId = 0;
             metadata.Metadata.Properties.Clear();
             _messageMetadataPool.Return(metadata);
 

--- a/src/DotPulsar/Extensions/SendExtensions.cs
+++ b/src/DotPulsar/Extensions/SendExtensions.cs
@@ -71,6 +71,7 @@ public static class SendExtensions
         }
         finally
         {
+            metadata.Metadata.SequenceId = 0;
             metadata.Metadata.Properties.Clear();
             _messageMetadataPool.Return(metadata);
         }


### PR DESCRIPTION
Fixes sequenceId not correctly set when using Send Extension methods and deduplication enabled.

# Description

Reset sequenceId before returning to pool for reuse

All other fields will not be sent when using the Send Extension methods and should therefore not have a value that needs to be reset.
