### PR TITLE
Centralize object pool for MessageMetadata

### DIFF
--- a/src/DotPulsar/Extensions/SendExtensions.cs
+++ b/src/DotPulsar/Extensions/SendExtensions.cs
@@ -15,7 +15,7 @@
 namespace DotPulsar.Extensions;
 
 using DotPulsar.Abstractions;
-using Microsoft.Extensions.ObjectPool;
+using DotPulsar.Internal;
 using System;
 using System.Buffers;
 using System.Threading;
@@ -26,14 +26,6 @@ using System.Threading.Tasks;
 /// </summary>
 public static class SendExtensions
 {
-    private static readonly ObjectPool<MessageMetadata> _messageMetadataPool;
-
-    static SendExtensions()
-    {
-        var messageMetadataPolicy = new DefaultPooledObjectPolicy<MessageMetadata>();
-        _messageMetadataPool = new DefaultObjectPool<MessageMetadata>(messageMetadataPolicy);
-    }
-
     /// <summary>
     /// Sends a message.
     /// </summary>
@@ -63,7 +55,7 @@ public static class SendExtensions
     /// </summary>
     public static async ValueTask<MessageId> Send<TMessage>(this ISend<TMessage> sender, TMessage message, CancellationToken cancellationToken = default)
     {
-        var metadata = _messageMetadataPool.Get();
+        var metadata = MessageMetadataObjectPool.Get();
 
         try
         {
@@ -71,9 +63,7 @@ public static class SendExtensions
         }
         finally
         {
-            metadata.Metadata.SequenceId = 0;
-            metadata.Metadata.Properties.Clear();
-            _messageMetadataPool.Return(metadata);
+            MessageMetadataObjectPool.Return(metadata);
         }
     }
 }

--- a/src/DotPulsar/Internal/MessageMetadataObjectPool.cs
+++ b/src/DotPulsar/Internal/MessageMetadataObjectPool.cs
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DotPulsar.Internal;
+
+using Microsoft.Extensions.ObjectPool;
+
+public static class MessageMetadataObjectPool
+{
+    private static readonly ObjectPool<MessageMetadata> _messageMetadataPool;
+
+    static MessageMetadataObjectPool()
+    {
+        var messageMetadataPolicy = new DefaultPooledObjectPolicy<MessageMetadata>();
+        _messageMetadataPool = new DefaultObjectPool<MessageMetadata>(messageMetadataPolicy);
+    }
+
+    public static MessageMetadata Get()
+    {
+        return _messageMetadataPool.Get();
+    }
+
+    public static void Return(MessageMetadata metadata)
+    {
+        metadata.SequenceId = 0;
+        metadata.Metadata.Properties.Clear();
+        _messageMetadataPool.Return(metadata);
+    }
+}


### PR DESCRIPTION
# Description

Ensures cleanup is consistent before returning objects to pool.

I have left the methods as public, which would allow users to reuse it in their own Send extension methods, but it does come with the caveat that those use cases may set properties that require cleanup. We could change the methods to be internal to prevent reuse.