### PR TITLE
Fix PingPongHandler doesn't kill the connection

### DIFF
--- a/src/DotPulsar/Internal/Abstractions/IConnection.cs
+++ b/src/DotPulsar/Internal/Abstractions/IConnection.cs
@@ -43,5 +43,5 @@ public interface IConnection : IAsyncDisposable
     Task<BaseCommand> Send(CommandGetOrCreateSchema command, CancellationToken cancellationToken);
     Task<BaseCommand> Send(CommandPartitionedTopicMetadata command, CancellationToken cancellationToken);
 
-    void MarkInactive();
+    Task<IConnection> WaitForInactive();
 }

--- a/src/DotPulsar/Internal/Abstractions/IConnection.cs
+++ b/src/DotPulsar/Internal/Abstractions/IConnection.cs
@@ -42,4 +42,6 @@ public interface IConnection : IAsyncDisposable
     Task Send(SendPackage command, TaskCompletionSource<BaseCommand> responseTcs, CancellationToken cancellationToken);
     Task<BaseCommand> Send(CommandGetOrCreateSchema command, CancellationToken cancellationToken);
     Task<BaseCommand> Send(CommandPartitionedTopicMetadata command, CancellationToken cancellationToken);
+
+    void MarkInactive();
 }

--- a/src/DotPulsar/Internal/PingPongHandler.cs
+++ b/src/DotPulsar/Internal/PingPongHandler.cs
@@ -30,8 +30,9 @@ public sealed class PingPongHandler : IAsyncDisposable
     private readonly CommandPong _pong;
     private long _lastCommand;
     private bool _waitForPong;
+    private readonly Action _inactiveCallback;
 
-    public PingPongHandler(IConnection connection, TimeSpan keepAliveInterval)
+    public PingPongHandler(IConnection connection, TimeSpan keepAliveInterval, Action inactiveCallback)
     {
         _connection = connection;
         _keepAliveInterval = keepAliveInterval;
@@ -40,6 +41,7 @@ public sealed class PingPongHandler : IAsyncDisposable
         _ping = new CommandPing();
         _pong = new CommandPong();
         _lastCommand = Stopwatch.GetTimestamp();
+        _inactiveCallback = inactiveCallback;
     }
 
     public bool Incoming(BaseCommand.Type commandType)
@@ -67,7 +69,7 @@ public sealed class PingPongHandler : IAsyncDisposable
             {
                 if (_waitForPong)
                 {
-                    _connection.MarkInactive();
+                    _inactiveCallback();
                     return;
                 }
                 Task.Factory.StartNew(() =>

--- a/src/DotPulsar/Internal/PingPongHandler.cs
+++ b/src/DotPulsar/Internal/PingPongHandler.cs
@@ -67,7 +67,7 @@ public sealed class PingPongHandler : IAsyncDisposable
             {
                 if (_waitForPong)
                 {
-                    _connection.DisposeAsync();
+                    _connection.MarkInactive();
                     return;
                 }
                 Task.Factory.StartNew(() =>

--- a/src/DotPulsar/Internal/PingPongHandler.cs
+++ b/src/DotPulsar/Internal/PingPongHandler.cs
@@ -63,11 +63,11 @@ public sealed class PingPongHandler : IAsyncDisposable
             var elapsed = TimeSpan.FromSeconds((now - lastCommand) / Stopwatch.Frequency);
             if (elapsed >= _keepAliveInterval)
             {
-                Task.Factory.StartNew(() => SendPing());
-                _timer.Change(_keepAliveInterval, TimeSpan.Zero);
+                _connection.DisposeAsync();
+                return;
             }
-            else
-                _timer.Change(_keepAliveInterval.Subtract(elapsed), TimeSpan.Zero);
+            Task.Factory.StartNew(() => SendPing());
+            _timer.Change(_keepAliveInterval, TimeSpan.Zero);
         }
         catch
         {

--- a/tests/DotPulsar.Tests/Internal/PingPongHandlerTest.cs
+++ b/tests/DotPulsar.Tests/Internal/PingPongHandlerTest.cs
@@ -17,6 +17,7 @@ namespace DotPulsar.Tests.Internal;
 using DotPulsar.Internal;
 using DotPulsar.Internal.Abstractions;
 using DotPulsar.Internal.PulsarApi;
+using NSubstitute;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,70 +30,20 @@ public class PingPongHandlerTest
     public async Task Watch_GivenConnectionNotAlive_ShouldDisposeConnection()
     {
         var countDown = new CountdownEvent(1);
-        var connection = new MockConnection();
+        var connection = Substitute.For<IConnection>();
         var keepAliveInterval = TimeSpan.FromSeconds(1);
-        connection.PingCallback = () => countDown.Signal();
+        connection.When(c => c.MarkInactive()).Do(c => countDown.Signal());
         var pingPongHandler = new PingPongHandler(connection, keepAliveInterval);
 
         // Wait for the first Ping
         // The ping arrive time should be at (keepAliveInterval, 2*keepAliveInterval)
         countDown.Wait(2 * keepAliveInterval);
         pingPongHandler.Incoming(BaseCommand.Type.Pong);
-        Assert.False(connection.IsDispose);
+        connection.DidNotReceive().MarkInactive();
 
         // Wait for the second Ping, but we don't reply with Pong.
         // The connection disposed time should be at (2*keepAliveInterval, 3*keepAliveInterval)
         await Task.Delay(3 * keepAliveInterval);
-        Assert.True(connection.IsDispose);
-    }
-
-    private class MockConnection : IConnection
-    {
-        public volatile bool IsDispose;
-        public Action PingCallback = (() => { });
-        public ValueTask DisposeAsync() => throw new System.NotImplementedException();
-        public ValueTask<bool> HasChannels(CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<ProducerResponse> Send(CommandProducer command, IChannel channel, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<SubscribeResponse> Send(CommandSubscribe command, IChannel channel, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task Send(CommandPing command, CancellationToken cancellationToken)
-        {
-            PingCallback();
-            return Task.CompletedTask;
-        }
-        public Task Send(CommandPong command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task Send(CommandAck command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task Send(CommandFlow command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task Send(CommandRedeliverUnacknowledgedMessages command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<BaseCommand> Send(CommandUnsubscribe command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<BaseCommand> Send(CommandConnect command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<BaseCommand> Send(CommandLookupTopic command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<BaseCommand> Send(CommandSeek command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<BaseCommand> Send(CommandGetLastMessageId command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<BaseCommand> Send(CommandCloseProducer command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<BaseCommand> Send(CommandCloseConsumer command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task Send(SendPackage command, TaskCompletionSource<BaseCommand> responseTcs, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<BaseCommand> Send(CommandGetOrCreateSchema command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public Task<BaseCommand> Send(CommandPartitionedTopicMetadata command, CancellationToken cancellationToken) =>
-            throw new System.NotImplementedException();
-        public void MarkInactive()
-        {
-            this.IsDispose = true;
-        }
+        connection.Received().MarkInactive();
     }
 }

--- a/tests/DotPulsar.Tests/Internal/PingPongHandlerTest.cs
+++ b/tests/DotPulsar.Tests/Internal/PingPongHandlerTest.cs
@@ -50,11 +50,7 @@ public class PingPongHandlerTest
     {
         public volatile bool IsDispose;
         public Action PingCallback = (() => { });
-        public ValueTask DisposeAsync()
-        {
-            this.IsDispose = true;
-            return ValueTask.CompletedTask;
-        }
+        public ValueTask DisposeAsync() => throw new System.NotImplementedException();
         public ValueTask<bool> HasChannels(CancellationToken cancellationToken) =>
             throw new System.NotImplementedException();
         public Task<ProducerResponse> Send(CommandProducer command, IChannel channel, CancellationToken cancellationToken) =>
@@ -94,5 +90,9 @@ public class PingPongHandlerTest
             throw new System.NotImplementedException();
         public Task<BaseCommand> Send(CommandPartitionedTopicMetadata command, CancellationToken cancellationToken) =>
             throw new System.NotImplementedException();
+        public void MarkInactive()
+        {
+            this.IsDispose = true;
+        }
     }
 }

--- a/tests/DotPulsar.Tests/Internal/PingPongHandlerTest.cs
+++ b/tests/DotPulsar.Tests/Internal/PingPongHandlerTest.cs
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DotPulsar.Tests.Internal;
+
+using DotPulsar.Internal;
+using DotPulsar.Internal.Abstractions;
+using DotPulsar.Internal.PulsarApi;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+[Trait("Category", "Unit")]
+public class PingPongHandlerTest
+{
+    [Fact]
+    public async Task Watch_GivenConnectionNotAlive_ShouldDisposeConnection()
+    {
+        var countDown = new CountdownEvent(1);
+        var connection = new MockConnection();
+        var keepAliveInterval = TimeSpan.FromSeconds(1);
+        connection.PingCallback = () => countDown.Signal();
+        var pingPongHandler = new PingPongHandler(connection, keepAliveInterval);
+
+        // Wait for the first Ping
+        // The ping arrive time should be at (keepAliveInterval, 2*keepAliveInterval)
+        countDown.Wait(2 * keepAliveInterval);
+        pingPongHandler.Incoming(BaseCommand.Type.Pong);
+        Assert.False(connection.IsDispose);
+
+        // Wait for the second Ping, but we don't reply with Pong.
+        // The connection disposed time should be at (2*keepAliveInterval, 3*keepAliveInterval)
+        await Task.Delay(3 * keepAliveInterval);
+        Assert.True(connection.IsDispose);
+    }
+
+    private class MockConnection : IConnection
+    {
+        public volatile bool IsDispose;
+        public Action PingCallback = (() => { });
+        public ValueTask DisposeAsync()
+        {
+            this.IsDispose = true;
+            return ValueTask.CompletedTask;
+        }
+        public ValueTask<bool> HasChannels(CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<ProducerResponse> Send(CommandProducer command, IChannel channel, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<SubscribeResponse> Send(CommandSubscribe command, IChannel channel, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task Send(CommandPing command, CancellationToken cancellationToken)
+        {
+            PingCallback();
+            return Task.CompletedTask;
+        }
+        public Task Send(CommandPong command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task Send(CommandAck command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task Send(CommandFlow command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task Send(CommandRedeliverUnacknowledgedMessages command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<BaseCommand> Send(CommandUnsubscribe command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<BaseCommand> Send(CommandConnect command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<BaseCommand> Send(CommandLookupTopic command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<BaseCommand> Send(CommandSeek command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<BaseCommand> Send(CommandGetLastMessageId command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<BaseCommand> Send(CommandCloseProducer command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<BaseCommand> Send(CommandCloseConsumer command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task Send(SendPackage command, TaskCompletionSource<BaseCommand> responseTcs, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<BaseCommand> Send(CommandGetOrCreateSchema command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+        public Task<BaseCommand> Send(CommandPartitionedTopicMetadata command, CancellationToken cancellationToken) =>
+            throw new System.NotImplementedException();
+    }
+}


### PR DESCRIPTION
Fixes #166 

# Description

The root cause of #166 is that the PingPongHandler doesn't work expectedly. 

The expected behavior for PingPongHandler is as follows:
- Send a ping every keepAliveIntervarl(default is 30s)
- Waiting for the Pong responses or any other command.
- Trigger the Watch task at the next keepAliveIntervarl. If there are no incoming commands in this period. Then the connection is dead, and we should dispose the connection.

But the current behavior is triggering the Watch every keepAliveIntervarl. If there are no incoming commands, then send the Ping. But there are no any actions to the connection.

I have also simplified the implementation of PingPongHandler. The previous implementation has the possible loss of fraction here: https://github.com/apache/pulsar-dotpulsar/blob/ab7b00315ea04da7175db102d542ee039b6e738a/src/DotPulsar/Internal/PingPongHandler.cs#L63

I changed it to use a bool `_waitForPongResponse`. This seems more intuitive.


# Regression

It's not a regression.

# Testing

I have tested it, and it could fix #166 .
This PR also adds the `PingPongHandlerTest`.