### PR TITLE
Consumer and Reader state

### DIFF
--- a/src/DotPulsar/ConsumerState.cs
+++ b/src/DotPulsar/ConsumerState.cs
@@ -40,6 +40,11 @@ public enum ConsumerState : byte
     Faulted,
 
     /// <summary>
+    /// Some of the sub-consumers are disconnected.
+    /// </summary>
+    PartiallyConnected,
+
+    /// <summary>
     /// The consumer is connected and inactive. The subscription type is 'Failover' and this consumer is not the active consumer.
     /// </summary>
     Inactive,

--- a/src/DotPulsar/ReaderState.cs
+++ b/src/DotPulsar/ReaderState.cs
@@ -40,6 +40,11 @@ public enum ReaderState : byte
     Faulted,
 
     /// <summary>
+    /// Some of the sub-readers are disconnected.
+    /// </summary>
+    PartiallyConnected,
+
+    /// <summary>
     /// The reader has reached the end of the topic. This is a final state.
     /// </summary>
     ReachedEndOfTopic


### PR DESCRIPTION
# Description
Consumer and Reader state system improved to handle partitioned topics

During the work on the state system the following bugs were found and fixed:
It seems that the Reader and Consumer failed to close their state properly during disposal.
SubReader and subConsumer may have mistakenly triggered the state system for the Reader and Consumer, respectively.

# Testing
All tests are green