### PR TITLE
TryParse missing CHANGELOG and dev docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - Added partitioned topic support for the Consumer and Reader (was already implemented for the Producer)
 - MessageId now includes an extra field for the topic
+- A TryParse method is added to MessageId. Therefore, it is now possible to parse a string into a MessageId object
 - Support for `ProducerAccessMode` to prevent multiple producers on a single topic
 - A new `Fenced` state for producers which is a final state
 - The ability to explicitly set compression information on an outgoing message using `MessageMetadata` (for sending pre-compressed messages)

--- a/src/DotPulsar/MessageId.cs
+++ b/src/DotPulsar/MessageId.cs
@@ -153,12 +153,20 @@ public sealed class MessageId : IEquatable<MessageId>, IComparable<MessageId>
     }
 
     /// <summary>
-    /// Converts a string into a MessageId
+    /// Converts the string representation of a message id to its object equivalent. A return value indicates whether the conversion succeeded.
     /// </summary>
-    /// <returns>True is successfull and false if not</returns>
+    /// <param name="s">A string containing a message id to convert.</param>
+    /// <param name="result">
+    /// When this method returns, contains the MessageId equivalent of the string contained in s, if the conversion succeeded, or MessageId.Earliest if the conversion failed.
+    /// The conversion fails if the s parameter is null or Empty, or is not of the correct format.
+    /// This parameter is passed uninitialized; any value originally supplied in result will be overwritten.
+    /// </param>
+    /// <returns> true if the string was converted successfully; otherwise, false. </returns>
     public static bool TryParse(string s, out MessageId result)
     {
         result = Earliest;
+        if (string.IsNullOrWhiteSpace(s))
+            return false;
         var input = s.AsMemory();
         var startOfNextEntry = 0;
         var index = 0;


### PR DESCRIPTION
# Description
TryParse improvements

TryParse didn't guard for null or whitespace
Added missing feature in CHANGELOG.md
Improved code doc for TryParse