### PR TITLE
GetLastMessageId Improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- When calling GetLastMessageId(s) on a Reader or Consumer, it returns a MessageId without the topic field if
+  MessageId.Earliest is found.
+
 ## [3.0.0] - 2023-08-30
 
 ### Added


### PR DESCRIPTION
# Description
When returning a MessageId, the topic should not be included if it is a MessageId.Earliest. Failure to remove the topic will cause issues when attempting to compare with another MessageId.Earliest.

# Testing

All green