### PR TITLE
Consumer and Reader do not throw FaultedException as excepted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - When calling GetLastMessageId(s) on a Reader or Consumer, it returns a MessageId without the topic field if
   MessageId.Earliest is found.
 
+### Fixed
+
+- Fixed issue with DotPulsar client not handling connection faults for consumers and readers.
+
 ## [3.0.0] - 2023-08-30
 
 ### Added

--- a/src/DotPulsar/Internal/SubConsumer.cs
+++ b/src/DotPulsar/Internal/SubConsumer.cs
@@ -145,7 +145,7 @@ public sealed class SubConsumer<TMessage> : IConsumer<TMessage>, IContainsChanne
             throw new ConsumerDisposedException(GetType().FullName!);
 
         if (_faultException is not null)
-            throw new ConsumerFaultedException(_faultException);
+            throw _faultException;
     }
 
     public async Task EstablishNewChannel(CancellationToken cancellationToken)

--- a/src/DotPulsar/Internal/SubReader.cs
+++ b/src/DotPulsar/Internal/SubReader.cs
@@ -148,7 +148,7 @@ public sealed class SubReader<TMessage> : IContainsChannel, IReader<TMessage>
             throw new ReaderDisposedException(GetType().FullName!);
 
         if (_faultException is not null)
-            throw new ReaderFaultedException(_faultException);
+            throw _faultException;
     }
 
     public async ValueTask ChannelFaulted(Exception exception)


### PR DESCRIPTION
# Description

The Consumer and Reader didn't throw FaultedException in two scenarios where it should.

Consumer
1:
After the initial setup of the DotPulsar client where it can't connect to the cluster. Creating a consumer and using Receive didn't produce a ConsumerFaultedException as it should.

2:
After the initial setup of the DotPulsar client where it can't connect to the cluster and is in a faulted state. Creating a consumer and using Receive didn't produce a ConsumerFaultedException as it should.

Reader
1:
After the initial setup of the DotPulsar client where it can't connect to the cluster. Creating a reader and using Receive didn't produce a ReaderFaultedException as it should.

2:
After the initial setup of the DotPulsar client where it can't connect to the cluster and is in a faulted state. Creating a reader and using Receive didn't produce a ReaderFaultedException as it should.

All the scenarios are fixed, and tests are written in ConsumerTests.cs ReaderTests.cs confirming the fix.
# Regression

Yes, before version 3.0.0 it worked.

# Testing

Added four new tests and confirmed that they all are green 🟢 