### PR TITLE
SubReader still attached topic name on a topic with no messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- When calling GetLastMessageId(s) on a SubReader code was still adding the topic unnecessarily
+
 ## [3.0.1] - 2023-09-15
 
 ### Changed

--- a/src/DotPulsar/Internal/SubReader.cs
+++ b/src/DotPulsar/Internal/SubReader.cs
@@ -82,8 +82,7 @@ public sealed class SubReader<TMessage> : IContainsChannel, IReader<TMessage>
     private async ValueTask<MessageId> InternalGetLastMessageId(CommandGetLastMessageId command, CancellationToken cancellationToken)
     {
         Guard();
-        var messageId = await _channel.Send(command, cancellationToken).ConfigureAwait(false);
-        return new MessageId(messageId.LedgerId, messageId.EntryId, messageId.Partition, messageId.BatchIndex, Topic);
+        return await _channel.Send(command, cancellationToken).ConfigureAwait(false);
     }
 
     public async ValueTask<IMessage<TMessage>> Receive(CancellationToken cancellationToken)

--- a/tests/DotPulsar.Tests/ConsumerTests.cs
+++ b/tests/DotPulsar.Tests/ConsumerTests.cs
@@ -38,6 +38,23 @@ public class ConsumerTests
     }
 
     [Fact]
+    public async Task GetLastMessageId_GivenEmptyTopic_ShouldBeEqualToMessageIdEarliest()
+    {
+        //Arrange
+        const string topicName = $"consumer-{nameof(GetLastMessageId_GivenEmptyTopic_ShouldBeEqualToMessageIdEarliest)}";
+        const string subscriptionName = "subscription-given-given-empty-topic";
+        const string consumerName = $"consumer-given-empty-topic";
+        await using var client = CreateClient();
+        await using var consumer = CreateConsumer(client, SubscriptionInitialPosition.Earliest, topicName, consumerName, subscriptionName);
+
+        //Act
+        var actual = await consumer.GetLastMessageId();
+
+        //Assert
+        actual.Should().BeEquivalentTo(MessageId.Earliest);
+    }
+
+    [Fact]
     public async Task GetLastMessageId_GivenNonPartitionedTopic_ShouldGetMessageIdFromPartition()
     {
         //Arrange
@@ -144,6 +161,24 @@ public class ConsumerTests
                 expected.Add(messageId);
             }
         }
+
+        //Act
+        var actual = await consumer.GetLastMessageIds();
+
+        //Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task GetLastMessageIds_GivenEmptyTopic_ShouldBeEqualToMessageIdEarliest()
+    {
+        //Arrange
+        const string topicName = $"consumer-{nameof(GetLastMessageIds_GivenEmptyTopic_ShouldBeEqualToMessageIdEarliest)}";
+        const string subscriptionName = "subscription-given-given-empty-topic";
+        const string consumerName = $"consumer-given-empty-topic";
+        await using var client = CreateClient();
+        await using var consumer = CreateConsumer(client, SubscriptionInitialPosition.Earliest, topicName, consumerName, subscriptionName);
+        var expected = new List<MessageId>() { MessageId.Earliest };
 
         //Act
         var actual = await consumer.GetLastMessageIds();

--- a/tests/DotPulsar.Tests/ReaderTests.cs
+++ b/tests/DotPulsar.Tests/ReaderTests.cs
@@ -38,6 +38,21 @@ public class ReaderTests
     }
 
     [Fact]
+    public async Task GetLastMessageId_GivenEmptyTopic_ShouldBeEqualToMessageIdEarliest()
+    {
+        //Arrange
+        const string topicName = $"reader-{nameof(GetLastMessageId_GivenEmptyTopic_ShouldBeEqualToMessageIdEarliest)}";
+        await using var client = CreateClient();
+        await using var reader = CreateReader(client, MessageId.Earliest, topicName);
+
+        //Act
+        var actual = await reader.GetLastMessageId();
+
+        //Assert
+        actual.Should().BeEquivalentTo(MessageId.Earliest);
+    }
+
+    [Fact]
     public async Task GetLastMessageId_GivenNonPartitionedTopic_ShouldGetMessageId()
     {
         //Arrange
@@ -82,6 +97,22 @@ public class ReaderTests
 
         //Assert
         exception.Should().BeOfType<NotSupportedException>();
+    }
+
+    [Fact]
+    public async Task GetLastMessageIds_GivenEmptyTopic_ShouldBeEqualToMessageIdEarliest()
+    {
+        //Arrange
+        const string topicName = $"reader-{nameof(GetLastMessageIds_GivenEmptyTopic_ShouldBeEqualToMessageIdEarliest)}";
+        await using var client = CreateClient();
+        await using var reader = CreateReader(client, MessageId.Earliest, topicName);
+        var expected = new List<MessageId>() { MessageId.Earliest };
+
+        //Act
+        var actual = await reader.GetLastMessageIds();
+
+        //Assert
+        actual.Should().BeEquivalentTo(expected);
     }
 
     [Fact]


### PR DESCRIPTION
# Description
Consumers and readers were attaching the topic name even when there were no messages available. This issue has been resolved in https://github.com/apache/pulsar-dotpulsar/pull/175 in the ConsumerChannel. However, the SubReader code was still adding the topic unnecessarily. I have now removed this code and added tests to ensure that both the reader and consumer are functioning properly.

# Testing

All test green