### PR TITLE
Update ci-unit.yaml

### DIFF
--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -33,12 +33,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
+        id: setupstep
         with:
           dotnet-version: '7.0.x'
 
       - name: run unit tests
-        run: dotnet test ./tests/DotPulsar.Tests/DotPulsar.Tests.csproj --logger "trx;verbosity=detailed"
+        run: |
+          echo 'Dotnet Version: ${{ steps.setupstep.outputs.dotnet-version }}
+          dotnet test ./tests/DotPulsar.Tests/DotPulsar.Tests.csproj --logger "trx;verbosity=detailed"
 
       - name: package artifacts
         if: failure()
@@ -61,11 +64,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
+        id: setupstep
         with:
           dotnet-version: '7.0.x'
       - name: Build docs with docfx
         run: |
+          echo 'Dotnet Version: ${{ steps.setupstep.outputs.dotnet-version }}
           dotnet tool update -g docfx
           dotnet build -p:TargetFramework=net7.0
           docfx docs/api/docfx.json

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: run unit tests
         run: |
-          echo 'Dotnet Version: ${{ steps.setupstep.outputs.dotnet-version }}
+          echo 'Dotnet Version: ${{ steps.setupstep.outputs.dotnet-version }}'
           dotnet test ./tests/DotPulsar.Tests/DotPulsar.Tests.csproj --logger "trx;verbosity=detailed"
 
       - name: package artifacts
@@ -70,7 +70,7 @@ jobs:
           dotnet-version: '7.0.x'
       - name: Build docs with docfx
         run: |
-          echo 'Dotnet Version: ${{ steps.setupstep.outputs.dotnet-version }}
+          echo 'Dotnet Version: ${{ steps.setupstep.outputs.dotnet-version }}'
           dotnet tool update -g docfx
           dotnet build -p:TargetFramework=net7.0
           docfx docs/api/docfx.json


### PR DESCRIPTION
Update to latest step and print out the dotnet version used

See release notes for details https://github.com/actions/setup-dotnet/releases

# Description

Adds print out of running dotnet version before calling dotnet

# Testing

Unable to test before PR is created