### PR TITLE
Matrix build to run unit tests on all supported .NET versions

### DIFF
--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -30,13 +30,17 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    strategy:
+      matrix:
+        dotnet: [ '6.0.x', '7.0.x' ]
+    name: Dotnet ${{ matrix.dotnet }} unit tests
     steps:
       - uses: actions/checkout@v3
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         id: setupstep
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: ${{ matrix.dotnet }}
 
       - name: run unit tests
         run: |


### PR DESCRIPTION
Matrix build

# Description

Run a matrix build to allow running tests on multiple versions of dotnet

# Testing

Unable to test before PR is created