### PR TITLE
Stop duplicate code comments for code review.

### DIFF
--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -42,20 +42,3 @@ jobs:
         run: |
           echo 'Dotnet Version: ${{ steps.setupstep.outputs.dotnet-version }}'
           dotnet test ./tests/DotPulsar.Tests/DotPulsar.Tests.csproj --logger "trx;verbosity=detailed"
-
-  doc-tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
-        id: setupstep
-        with:
-          dotnet-version: '7.0.x'
-      - name: Build docs with docfx
-        run: |
-          echo 'Dotnet Version: ${{ steps.setupstep.outputs.dotnet-version }}'
-          dotnet tool update -g docfx
-          dotnet build -p:TargetFramework=net7.0
-          docfx docs/api/docfx.json


### PR DESCRIPTION
# Description
When reviewing a pull request, duplicated errors pollute the code view unnecessarily.

Example
![image](https://github.com/apache/pulsar-dotpulsar/assets/1580435/ea15503f-503c-4d77-b7c4-c7958b9cdb1e)

When reviewing code. We just want a clean view to do it.

