### PR TITLE
Remove the unused artifacts from the ci-unit.

### DIFF
--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -43,21 +43,6 @@ jobs:
           echo 'Dotnet Version: ${{ steps.setupstep.outputs.dotnet-version }}'
           dotnet test ./tests/DotPulsar.Tests/DotPulsar.Tests.csproj --logger "trx;verbosity=detailed"
 
-      - name: package artifacts
-        if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          find . -type d -name "TestResults" -exec cp --parents -R {} artifacts/ \;
-          zip -r artifacts.zip artifacts
-
-      - name: upload artifacts
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: artifacts
-          path: artifacts.zip
-
   doc-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 120


### PR DESCRIPTION
Fixes GHA: Artifacts #182

# Description
Our CI pipeline works with artifacts, but I don't think we really use them for anything.
I opened an issue #182 trying to figure out why it was added in 2020 and what it does.
Now it has nearly been a week without any response.

# Testing
Testing this change is challenging since GitHub doesn't offer a GHA testing environment. Therefor, I have not been able to test if it breaks anything.
However, it is worth noting that, based on the available information, it appears that we are not actively utilizing these artifacts.