### PR TITLE
Streamlined the release process for DotPulsar.

### DIFF
--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -48,10 +48,10 @@ jobs:
         run: dotnet restore
 
       - name: Build library (Release)
-        run: dotnet build --no-restore /p:PackageVersion=$VERSION -c release src/DotPulsar/DotPulsar.csproj
+        run: dotnet build --no-restore /p:PackageVersion=$VERSION /p:ContinuousIntegrationBuild=true -c release src/DotPulsar/DotPulsar.csproj
 
       - name: Create nuget package
-        run: dotnet pack /p:PackageVersion=$VERSION -c release --include-symbols
+        run: dotnet pack /p:PackageVersion=$VERSION /p:ContinuousIntegrationBuild=true -c release --include-symbols
 
       - name: Publish the package to nuget.org
         run: dotnet nuget push src/DotPulsar/bin/release/*.nupkg --api-key $NUGET_AUTH_TOKEN --source https://api.nuget.org/v3/index.json

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -56,7 +56,7 @@ Bump up the version number as follows.
 
 1. Update the version and tag of a package.
 
-Update the information of the new release in the `DotPulsar.csproj` and `CHANGELOG.md` files and send a PR for with the changes.
+Update the information in `CHANGELOG.md` and send a PR for with the changes.
 
 Be sure to make the commit message `Make ready for release X.X.X-rc-X`
 

--- a/src/DotPulsar/DotPulsar.csproj
+++ b/src/DotPulsar/DotPulsar.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
-    <Version>3.0.2</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Authors>ApachePulsar,DanskeCommodities,dblank</Authors>
@@ -43,9 +42,5 @@
   <ItemGroup>
     <None Include="PackageIcon.png" Pack="true" PackagePath="/" Visible="False" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
# Description
The version tag has been removed from the DotPulsar.csproj file, as the continuous delivery (CD) pipeline now uses the git tag as version information. Additionally, the ContinuousIntegrationBuild in the file has been removed and moved to publish-to-nuget.yml, so it can be handled by a command line switch to dotnet. We have also updated the release-process.md file to reflect the change that version information is no longer needed in the DotPulsar.csproj file.

# Testing

<!-- What kind of testing has been done with the fix. -->
Testing this workflow is challenging since GitHub doesn't offer a straightforward testing environment. I initially tested it on my personal project, [nugettestrepo_delete_me_soon](https://github.com/entvex/nugettestrepo_delete_me_soon), and confirmed its functionality. Later, I adapted the GHA configuration to match the DotPulsar folder structure. Unfortunately, due to GitHub's limitations, there are no comprehensive testing options available beyond these steps.