### PR TITLE
Add Toxiproxy to simulate errors in distributed systems

### DIFF
--- a/tests/DotPulsar.Tests/DotPulsar.Tests.csproj
+++ b/tests/DotPulsar.Tests/DotPulsar.Tests.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Testcontainers" Version="3.6.0" />
+    <PackageReference Include="ToxiproxyNetCore" Version="1.0.35" />
     <PackageReference Include="xunit" Version="2.6.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Description
This commit adds Toxiproxy to our system to help us simulate common issues in distributed systems such as fault tolerance and error recovery. This will help us identify and fix issues before they become critical.