### PR TITLE
Web api

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -50,4 +50,3 @@ notifications:
   issues:       commits@pulsar.apache.org
   pullrequests: commits@pulsar.apache.org
   discussions:  dev@pulsar.apache.org
-  jira_options: link label

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,6 +20,8 @@
 github:
   description: "The official .NET client library for Apache Pulsar"
   homepage: https://pulsar.apache.org/
+  ghp_branch:  gh-pages
+  ghp_path:    /docs
   labels:
     - pulsar
     - pubsub

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -57,3 +57,29 @@ jobs:
         run: dotnet nuget push src/DotPulsar/bin/Release/*.nupkg --api-key $NUGET_AUTH_TOKEN --source https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_KEY }}
+          
+  build-web-api:
+    timeout-minutes: 120
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build docs with docfx
+        run: |
+          dotnet tool update -g docfx
+          dotnet build -p:TargetFramework=net8.0
+          docfx docs/api/docfx.json
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -59,13 +59,14 @@ jobs:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_KEY }}
           
   build-web-api:
-    timeout-minutes: 120
+    timeout-minutes: 30
     needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - name: Check Out
+        uses: actions/checkout@v3
       
       - name: Setup .NET
         uses: actions/setup-dotnet@v3


### PR DESCRIPTION
# Description
When we release a new version of DotPulsar we would like to build the web API and deploy it to GitHub pages.
Please see [wiki apache](https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#Git.asf.yamlfeatures-GitHubPages) for the docs I used.

I am unsure if I have to create a branch called "gh-pages" or if Apache does that automatically when the changes to the .asf.yaml gets merged. Do you know @tisonkun ?

# Testing
Testing this workflow is challenging since GitHub doesn't offer a straightforward testing environment. I can't test it initially on a personal project. Because ASF are using a specific .asf.yaml that is not part of the normal GitHub workflow. But errors should not affect the "publish to nuget" operation, as the new job is only executed after that part has finished successfully. Unfortunately, due to GitHub's limitations, there are no comprehensive testing options available beyond these steps.