### PR TITLE
Add partition router tests and update xunit packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- RoundRobinPartitionRouter and SinglePartitionRouter could return a negative number. They have been changed to ensure they always return a non-negative integer.
+
 ## [3.2.0] - 2024-04-09
 
 ### Added

--- a/src/DotPulsar/RoundRobinPartitionRouter.cs
+++ b/src/DotPulsar/RoundRobinPartitionRouter.cs
@@ -18,7 +18,7 @@ using DotPulsar.Abstractions;
 using HashDepot;
 
 /// <summary>
-/// The round robin partition messages router, which is the default router.
+/// The round-robin partition messages router, which is the default router.
 /// If a key is provided, the producer will hash the key and publish the message to a particular partition.
 /// If a key is not provided, the producer will publish messages across all partitions in a round-robin fashion to achieve maximum throughput.
 /// </summary>
@@ -27,7 +27,7 @@ public sealed class RoundRobinPartitionRouter : IMessageRouter
     private int _partitionIndex;
 
     /// <summary>
-    /// Initializes a new instance of the round robin partition router
+    /// Initializes a new instance of the round-robin partition router
     /// </summary>
     public RoundRobinPartitionRouter()
     {
@@ -35,13 +35,13 @@ public sealed class RoundRobinPartitionRouter : IMessageRouter
     }
 
     /// <summary>
-    /// Choose a partition in round robin routing mode
+    /// Choose a partition in round-robin routing mode
     /// </summary>
     public int ChoosePartition(MessageMetadata messageMetadata, int numberOfPartitions)
     {
         var keyBytes = messageMetadata.KeyBytes;
         if (keyBytes is not null && keyBytes.Length > 0)
-            return (int) MurmurHash3.Hash32(keyBytes, 0) % numberOfPartitions;
+            return (int) (MurmurHash3.Hash32(keyBytes, 0) % numberOfPartitions);
 
         return Interlocked.Increment(ref _partitionIndex) % numberOfPartitions;
     }

--- a/src/DotPulsar/SinglePartitionRouter.cs
+++ b/src/DotPulsar/SinglePartitionRouter.cs
@@ -49,7 +49,7 @@ public sealed class SinglePartitionRouter : IMessageRouter
     {
         var keyBytes = messageMetadata.KeyBytes;
         if (keyBytes is not null && keyBytes.Length > 0)
-            return (int) MurmurHash3.Hash32(keyBytes, 0) % numberOfPartitions;
+            return (int) (MurmurHash3.Hash32(keyBytes, 0) % numberOfPartitions);
 
         if (_partitionIndex == -1)
             _partitionIndex = new Random().Next(0, numberOfPartitions);

--- a/tests/DotPulsar.Tests/DotPulsar.Tests.csproj
+++ b/tests/DotPulsar.Tests/DotPulsar.Tests.csproj
@@ -26,8 +26,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Testcontainers" Version="3.8.0" />
     <PackageReference Include="ToxiproxyNetCore" Version="1.0.35" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DotPulsar.Tests/Internal/RoundRobinPartitionRouterTests.cs
+++ b/tests/DotPulsar.Tests/Internal/RoundRobinPartitionRouterTests.cs
@@ -1,0 +1,37 @@
+﻿namespace DotPulsar.Tests.Internal;
+
+public class RoundRobinPartitionRouterTests
+{
+    [Fact]
+    public void ChoosePartition_GivenBytes_ShouldReturnNonNegativeInteger()
+    {
+        // Arrange
+        var router = new RoundRobinPartitionRouter();
+        var messageMetadata = new MessageMetadata
+        {
+            KeyBytes = [13, 144, 79, 245] //-179335155
+        };
+
+        //Act
+        var result = router.ChoosePartition(messageMetadata, 4);
+
+        //Assert
+        result.Should().BeInRange(0, 3);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(int.MaxValue)]
+    public void ChoosePartition_GivenNoMetadata_ShouldReturnNonNegativeInteger(int numberOfPartitions)
+    {
+        // Arrange
+        var router = new RoundRobinPartitionRouter();
+        var messageMetadata = new MessageMetadata();
+
+        //Act
+        var result = router.ChoosePartition(messageMetadata, numberOfPartitions);
+
+        //Assert
+        result.Should().BeInRange(0, numberOfPartitions);
+    }
+}

--- a/tests/DotPulsar.Tests/Internal/SinglePartitionRouterTests.cs
+++ b/tests/DotPulsar.Tests/Internal/SinglePartitionRouterTests.cs
@@ -1,0 +1,37 @@
+﻿namespace DotPulsar.Tests.Internal;
+
+public class SinglePartitionRouterTests
+{
+    [Fact]
+    public void ChoosePartition_GivenBytes_ShouldReturnNonNegativeInteger()
+    {
+        // Arrange
+        var router = new SinglePartitionRouter();
+        var messageMetadata = new MessageMetadata
+        {
+            KeyBytes = [13, 144, 79, 245] //-179335155
+        };
+
+        //Act
+        var result = router.ChoosePartition(messageMetadata, 4);
+
+        //Assert
+        result.Should().BeInRange(0, 3);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(int.MaxValue)]
+    public void ChoosePartition_GivenNoMetadata_ShouldReturnNonNegativeInteger(int numberOfPartitions)
+    {
+        // Arrange
+        var router = new SinglePartitionRouter();
+        var messageMetadata = new MessageMetadata();
+
+        //Act
+        var result = router.ChoosePartition(messageMetadata, numberOfPartitions);
+
+        //Assert
+        result.Should().BeInRange(0, numberOfPartitions);
+    }
+}


### PR DESCRIPTION
Fixes #213

# Description
Adjustments have been made to the implementation of SinglePartitionRouter and RoundRobinPartitionRouter so the that the ChoosePartition method return non-negative integers.

# Testing
Added unit tests for the SinglePartitionRouter and RoundRobinPartitionRouter classes. These tests check that chosen partitions return non-negative integers.