### PR TITLE
Update ToxiProxy and Pulsar images and adjust timeout intervals

### DIFF
--- a/src/DotPulsar/Internal/ConnectionPool.cs
+++ b/src/DotPulsar/Internal/ConnectionPool.cs
@@ -152,7 +152,7 @@ public sealed class ConnectionPool : IConnectionPool
             commandConnect = WithProxyToBroker(commandConnect, url.Logical);
 
         var connection = Connection.Connect(new PulsarStream(stream), _authentication, _keepAliveInterval, _closeInactiveConnectionsInterval);
-        _ = connection.OnStateChangeFrom(ConnectionState.Connected, CancellationToken.None).AsTask().ContinueWith(t => DisposeConnection(url, connection));
+        _ = connection.OnStateChangeFrom(ConnectionState.Connected, CancellationToken.None).AsTask().ContinueWith(t => DisposeConnection(url, connection), cancellationToken);
         var response = await connection.Send(commandConnect, cancellationToken).ConfigureAwait(false);
         response.Expect(BaseCommand.Type.Connected);
         _connections[url] = connection;

--- a/tests/DotPulsar.Tests/IntegrationFixture.cs
+++ b/tests/DotPulsar.Tests/IntegrationFixture.cs
@@ -69,7 +69,7 @@ public class IntegrationFixture : IAsyncLifetime
             .Build();
 
         _toxiProxy = new ContainerBuilder()
-            .WithImage("ghcr.io/shopify/toxiproxy:2.7.0")
+            .WithImage("ghcr.io/shopify/toxiproxy:2.9.0")
             .WithPortBinding(ToxiProxyControlPort, true)
             .WithPortBinding(ToxiProxyPort, true)
             .WithHostname("toxiproxy")
@@ -78,7 +78,7 @@ public class IntegrationFixture : IAsyncLifetime
             .Build();
 
         _pulsarCluster = new ContainerBuilder()
-            .WithImage("apachepulsar/pulsar:3.1.3")
+            .WithImage("apachepulsar/pulsar:3.2.3")
             .WithEnvironment(environmentVariables)
             .WithHostname("pulsar")
             .WithNetwork(_network)

--- a/tests/DotPulsar.Tests/PulsarClientTests.cs
+++ b/tests/DotPulsar.Tests/PulsarClientTests.cs
@@ -58,7 +58,7 @@ public sealed class PulsarClientTests : IDisposable
         {
             if (throwException)
                 throw new Exception();
-            var token = await _fixture.CreateToken(TimeSpan.FromSeconds(10), _cts.Token);
+            var token = await _fixture.CreateToken(TimeSpan.FromHours(2), _cts.Token);
             _testOutputHelper.Log($"Received token: '{token}'");
             return token;
         });
@@ -109,7 +109,7 @@ public sealed class PulsarClientTests : IDisposable
             if (refreshCount == 3)
                 tcs.SetResult();
 
-            var token = await _fixture.CreateToken(TimeSpan.FromSeconds(10), _cts.Token);
+            var token = await _fixture.CreateToken(TimeSpan.FromHours(2), _cts.Token);
             _testOutputHelper.Log($"Received token: '{token}'");
             return token;
         });


### PR DESCRIPTION
# Description
Two tests were failing using version 3.2.X of the Apache Pulsar Broker. Introducing longer timeout intervals in the tests, TokenSupplier_WhenTokenSupplierThrowsAnExceptionOnAuthChallenge_ShouldFaultProducer and TokenSupplier_WhenTokenSupplierReturnValidToken_ShouldStayConnected. Changing them from 10 seconds to 40 minutes for makes the tests work, nothing else changed.

Updates the used images of ToxiProxy and Pulsar in tests from versions 2.7.0 and 3.1.3 to 2.9.0 and 3.2.3 respectively to keep up with the latest versions.

Finally, I added a missing cancellation token in ConnectionPool.

# Testing

All tests are green again