### PR TITLE
Handle Pulsar Token bug in affected versions

### DIFF
--- a/src/DotPulsar/Internal/ConnectionPool.cs
+++ b/src/DotPulsar/Internal/ConnectionPool.cs
@@ -152,7 +152,7 @@ public sealed class ConnectionPool : IConnectionPool
             commandConnect = WithProxyToBroker(commandConnect, url.Logical);
 
         var connection = Connection.Connect(new PulsarStream(stream), _authentication, _keepAliveInterval, _closeInactiveConnectionsInterval);
-        _ = connection.OnStateChangeFrom(ConnectionState.Connected, CancellationToken.None).AsTask().ContinueWith(t => DisposeConnection(url, connection));
+        _ = connection.OnStateChangeFrom(ConnectionState.Connected, CancellationToken.None).AsTask().ContinueWith(t => DisposeConnection(url, connection), cancellationToken);
         var response = await connection.Send(commandConnect, cancellationToken).ConfigureAwait(false);
         response.Expect(BaseCommand.Type.Connected);
         _connections[url] = connection;


### PR DESCRIPTION
# Description
The commit updates the used images of ToxiProxy and Pulsar in tests from versions 2.7.0 and 3.1.3 to 2.9.0 and 3.2.3 respectively to keep up with the latest versions.

The issue arises because Apache Pulsar incorrectly treats seconds as milliseconds in specific versions. To address this, we multiply the value by 1000 when using affected versions.

Finally, I added a missing cancellation token in ConnectionPool.

# Testing
All tests now works on the newest Apache Pulsar version