### PR TITLE
Handle disconnect -> close properly in ChoosePartions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed race condition in `Producer` between `Send(...)` and `DisposeAsync()` dispose causing an unintended
+  `DivideByZeroException`. It now correctly throws a `ProducerClosedException`
+
 ## [3.3.0] - 2024-06-10
 
 ### Added


### PR DESCRIPTION
Fixes #{224}

# Description

A special case where a consumer closes before being connected, cause a non descriptive exception to be thrown to the user.

# Testing

Conditions manually created by inserting delays in source code.