### PR TITLE
Update .NET version to 9.0.x in workflows

### DIFF
--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         id: setupstep
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: run unit tests
         run: |

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: Restore dependencies
         run: dotnet restore


### PR DESCRIPTION
Updated the `dotnet-version` to '9.0.x' in both publish-to-nuget and ci-unit workflow YAML files. This ensures compatibility with the latest .NET features and improvements, enhancing the build and test processes.