### PR TITLE
Add ZLib compression using System.IO.Compression

### DIFF
--- a/benchmarks/Compression/Compress.cs
+++ b/benchmarks/Compression/Compress.cs
@@ -47,6 +47,13 @@ public class Compress
     }
 
     [Benchmark]
+    public void BuiltinZlib()
+    {
+        using var compressor = Factories.BuiltinZlibCompressionCompressorFactory.Create();
+        _ = compressor.Compress(Data);
+    }
+
+    [Benchmark]
     public void DotNetZip()
     {
         using var compressor = Factories.DotNetZipCompressorFactory.Create();

--- a/benchmarks/Compression/Decompress.cs
+++ b/benchmarks/Compression/Decompress.cs
@@ -37,6 +37,8 @@ public class Decompress
             K4aosCompressionLz4Data = compressor.Compress(data);
         using (var compressor = Factories.IronSnappyCompressorFactory.Create())
             IronSnappyData = compressor.Compress(data);
+        using (var compressor = Factories.BuiltinZlibCompressionCompressorFactory.Create())
+            BuiltinZlibData = compressor.Compress(data);
         using (var compressor = Factories.DotNetZipCompressorFactory.Create())
             DotNetZipData = compressor.Compress(data);
         using (var compressor = Factories.ZstdNetCompressorFactory.Create())
@@ -48,6 +50,7 @@ public class Decompress
     public int DecompressedSize { get; private set; }
     public ReadOnlySequence<byte> K4aosCompressionLz4Data { get; private set; }
     public ReadOnlySequence<byte> IronSnappyData { get; private set; }
+    public ReadOnlySequence<byte> BuiltinZlibData { get; private set; }
     public ReadOnlySequence<byte> DotNetZipData { get; private set; }
     public ReadOnlySequence<byte> ZstdNetData { get; private set; }
     public ReadOnlySequence<byte> ZstdSharpData { get; private set; }
@@ -64,6 +67,13 @@ public class Decompress
     {
         using var decompressor = Factories.IronSnappyDecompressorFactory.Create();
         _ = decompressor.Decompress(IronSnappyData, DecompressedSize);
+    }
+
+    [Benchmark]
+    public void BuiltinZlib()
+    {
+        using var decompressor = Factories.BuiltinZlibCompressionDecompressorFactory.Create();
+        _ = decompressor.Decompress(BuiltinZlibData, DecompressedSize);
     }
 
     [Benchmark]

--- a/benchmarks/Compression/Factories.cs
+++ b/benchmarks/Compression/Factories.cs
@@ -31,6 +31,11 @@ public static class Factories
         IronSnappyCompressorFactory = compressor!;
         IronSnappyDecompressorFactory = decompressor!;
 
+        if (!BuiltinZlibCompression.TryLoading(out compressor, out decompressor))
+            throw new Exception("Could not load BuiltinZlibCompression");
+        BuiltinZlibCompressionCompressorFactory = compressor!;
+        BuiltinZlibCompressionDecompressorFactory = decompressor!;
+
         if (!ZlibCompression.TryLoading(out compressor, out decompressor))
             throw new Exception("Could not load DotNetZip");
         DotNetZipCompressorFactory = compressor!;
@@ -52,6 +57,9 @@ public static class Factories
 
     public static ICompressorFactory IronSnappyCompressorFactory { get; }
     public static IDecompressorFactory IronSnappyDecompressorFactory { get; }
+
+    public static ICompressorFactory BuiltinZlibCompressionCompressorFactory { get; }
+    public static IDecompressorFactory BuiltinZlibCompressionDecompressorFactory { get; }
 
     public static ICompressorFactory DotNetZipCompressorFactory { get; }
     public static IDecompressorFactory DotNetZipDecompressorFactory { get; }

--- a/benchmarks/Compression/Program.cs
+++ b/benchmarks/Compression/Program.cs
@@ -33,6 +33,8 @@ static void OutputCompressionInfo(MessageSize size, MessageType type)
         Console.WriteLine($"\tCompressed with IronSnappy: {compressor.Compress(data).Length}");
     using (var compressor = Factories.DotNetZipCompressorFactory.Create())
         Console.WriteLine($"\tCompressed with DotNetZip: {compressor.Compress(data).Length}");
+    using (var compressor = Factories.BuiltinZlibCompressionCompressorFactory.Create())
+        Console.WriteLine($"\tCompressed with System.IO.Compression: {compressor.Compress(data).Length}");
     using (var compressor = Factories.ZstdNetCompressorFactory.Create())
         Console.WriteLine($"\tCompressed with ZstdNet: {compressor.Compress(data).Length}");
     using (var compressor = Factories.ZstdSharpCompressorFactory.Create())

--- a/src/DotPulsar/Internal/Compression/BuiltinZlibCompression.cs
+++ b/src/DotPulsar/Internal/Compression/BuiltinZlibCompression.cs
@@ -1,0 +1,63 @@
+namespace DotPulsar.Internal.Compression;
+
+using DotPulsar.Internal.Abstractions;
+using System.Buffers;
+using System.Reflection;
+
+public static class BuiltinZlibCompression
+{
+    public static bool TryLoading(out ICompressorFactory? compressorFactory, out IDecompressorFactory? decompressorFactory)
+    {
+        try
+        {
+            var assembly = Assembly.Load("System.IO.Compression");
+            var types = assembly.GetTypes();
+
+            // Find the ZLibStream
+            var zlibStreamType = types.FirstOrDefault(t => t.FullName == "System.IO.Compression.ZLibStream");
+
+            // Find the enum values for the ZLibStream constructors
+            var compressionLevelType = types.FirstOrDefault(t => t.FullName == "System.IO.Compression.CompressionLevel");
+            var compressionLevelOptimal = compressionLevelType?.GetEnumValues().GetValue(0);
+            var compressionModeType = types.FirstOrDefault(t => t.FullName == "System.IO.Compression.CompressionMode");
+            var compressionModeDecompress = compressionModeType?.GetEnumValues().GetValue(0);
+
+            compressorFactory = new CompressorFactory(PulsarApi.CompressionType.Zlib, () => new Compressor(CreateCompressor(zlibStreamType, compressionLevelOptimal)));
+            decompressorFactory = new DecompressorFactory(PulsarApi.CompressionType.Zlib, () => new Decompressor(CreateDecompressor(zlibStreamType, compressionModeDecompress)));
+
+            return CompressionTester.TestCompression(compressorFactory, decompressorFactory);
+        }
+        catch
+        {
+            // Ignore
+        }
+
+        compressorFactory = null;
+        decompressorFactory = null;
+
+        return false;
+    }
+
+    private static Func<ReadOnlySequence<byte>, ReadOnlySequence<byte>> CreateCompressor(Type? zlibStreamType, object? compressionLevelOptimal)
+        => data =>
+        {
+            using var dataStream = new MemoryStream(data.ToArray());
+            using var compressedStream = new MemoryStream();
+            using var compressor = (Stream) Activator.CreateInstance(zlibStreamType!, new object[] { compressedStream, compressionLevelOptimal! })!;
+            dataStream.CopyTo(compressor);
+            compressor.Close();
+            return new ReadOnlySequence<byte>(compressedStream.ToArray());
+        };
+
+    private static Func<ReadOnlySequence<byte>, int, ReadOnlySequence<byte>> CreateDecompressor(Type? zlibStreamType, object? compressionModeDecompress)
+        => (data, _) =>
+        {
+            using var dataStream = new MemoryStream(data.ToArray());
+            using var decompressedStream = new MemoryStream();
+            using var decompressor = (Stream) Activator.CreateInstance(zlibStreamType!, new object[] { dataStream, compressionModeDecompress! })!;
+            decompressor.CopyTo(decompressedStream);
+            decompressor.Close();
+            decompressedStream.Position = 0;
+            return new ReadOnlySequence<byte>(decompressedStream.ToArray());
+        };
+}

--- a/src/DotPulsar/Internal/Compression/CompressionFactories.cs
+++ b/src/DotPulsar/Internal/Compression/CompressionFactories.cs
@@ -46,7 +46,9 @@ public static class CompressionFactories
 
     private static void LoadSupportForZlib()
     {
-        if (ZlibCompression.TryLoading(out var compressorFactory, out var decompressorFactory))
+        if (BuiltinZlibCompression.TryLoading(out var compressorFactory, out var decompressorFactory))
+            Add(compressorFactory, decompressorFactory);
+        else if (ZlibCompression.TryLoading(out compressorFactory, out decompressorFactory))
             Add(compressorFactory, decompressorFactory);
     }
 


### PR DESCRIPTION
Fixes #236 

# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->
Adds a ZLib compression strategy implemented using types in the standard library namespace `System.IO.Compression`.

It's done in the same reflection-based style as the other libraries, since I'm not sure which dotnet versions DotPulsar support. This should work in modern versions, but I have not been able to figure out which release actually added the `ZLibStream` type, but it does exist in .net 6 at least.

Depending on targeting needs, this could be rewritten without reflection and the dependency on `DotNetZip` could be removed.

# Testing

<!-- What kind of testing has been done with the fix. -->

I have run the benchmark both in the current format, and with using the DotNetZip data as input for the new method, to ensure it works with "foreign" data.

It looks like `ZStdNet` does not support my M1 MacBook, so I have run a benchmark with that commented out. (Maybe a followup could be to make the benchmarks runnable directly on other architectures).

The results below only consider `DotNetZip` and the builtin ZLibStream:

### Compression
```
BenchmarkDotNet v0.14.0, macOS Sequoia 15.1.1 (24B91) [Darwin 24.1.0]
Apple M1 Pro 2.40GHz, 1 CPU, 10 logical and 10 physical cores
.NET SDK 9.0.100
  [Host]     : .NET 9.0.0 (9.0.24.52809), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 9.0.0 (9.0.24.52809), Arm64 RyuJIT AdvSIMD
```
| Method      | Size  | Type     | Mean         | Error      | StdDev    | Rank |
|------------ |------ |--------- |-------------:|-----------:|----------:|-----:|
| BuiltinZlib | Small | Protobuf |     14.54 μs |   0.076 μs |  0.067 μs |    1 |
| BuiltinZlib | Small | Json     |     15.15 μs |   0.060 μs |  0.053 μs |    2 |
| DotNetZip   | Small | Protobuf |     23.79 μs |   0.084 μs |  0.074 μs |    3 |
| DotNetZip   | Small | Json     |     27.88 μs |   0.292 μs |  0.273 μs |    4 |
| BuiltinZlib | Large | Protobuf | 16,617.32 μs |  35.357 μs | 33.073 μs |    5 |
| BuiltinZlib | Large | Json     | 17,271.07 μs |  25.601 μs | 23.947 μs |    6 |
| DotNetZip   | Large | Protobuf | 57,393.81 μs |  52.085 μs | 40.665 μs |    7 |
| DotNetZip   | Large | Json     | 81,048.88 μs | 114.971 μs | 96.006 μs |    8 |

### Decompression
```
BenchmarkDotNet v0.14.0, macOS Sequoia 15.1.1 (24B91) [Darwin 24.1.0]
Apple M1 Pro 2.40GHz, 1 CPU, 10 logical and 10 physical cores
.NET SDK 9.0.100
  [Host]     : .NET 9.0.0 (9.0.24.52809), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 9.0.0 (9.0.24.52809), Arm64 RyuJIT AdvSIMD
```
| Method      | Size  | Type     | Mean          | Error      | StdDev     | Rank |
|------------ |------ |--------- |--------------:|-----------:|-----------:|-----:|
| BuiltinZlib | Small | Protobuf |      5.879 μs |  0.0179 μs |  0.0150 μs |    1 |
| BuiltinZlib | Small | Json     |      6.358 μs |  0.0152 μs |  0.0142 μs |    2 |
| DotNetZip   | Small | Protobuf |     12.290 μs |  0.0335 μs |  0.0261 μs |    3 |
| DotNetZip   | Small | Json     |     13.448 μs |  0.0618 μs |  0.0516 μs |    4 |
| BuiltinZlib | Large | Protobuf |  3,747.056 μs | 14.2181 μs | 12.6040 μs |    5 |
| BuiltinZlib | Large | Json     |  4,836.137 μs | 38.5319 μs | 36.0428 μs |    6 |
| DotNetZip   | Large | Protobuf |  9,264.227 μs | 32.0810 μs | 28.4390 μs |    7 |
| DotNetZip   | Large | Json     | 12,252.336 μs | 39.5191 μs | 36.9661 μs |    8 |

