### PR TITLE
Add possibility of setting a prefix for the subscription for readers.

### DIFF
--- a/src/DotPulsar/Abstractions/IReaderBuilder.cs
+++ b/src/DotPulsar/Abstractions/IReaderBuilder.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -48,6 +48,11 @@ public interface IReaderBuilder<TMessage>
     /// Set the topic for this reader. This is required.
     /// </summary>
     IReaderBuilder<TMessage> Topic(string topic);
+
+    /// <summary>
+    /// Set the prefix for the subscription being created by this reader. This is optional.
+    /// </summary>
+    IReaderBuilder<TMessage> SubscriptionNamePrefix(string subscriptionNamePrefix);
 
     /// <summary>
     /// Create the reader.

--- a/src/DotPulsar/Internal/Reader.cs
+++ b/src/DotPulsar/Internal/Reader.cs
@@ -270,6 +270,11 @@ public sealed class Reader<TMessage> : IReader<TMessage>
     {
         var correlationId = Guid.NewGuid();
         var subscription = $"Reader-{correlationId:N}";
+        if (!string.IsNullOrEmpty(_readerOptions.SubscriptionNamePrefix))
+        {
+            subscription = $"{_readerOptions.SubscriptionNamePrefix}-{subscription}";
+        }
+
         var subscribe = new CommandSubscribe
         {
             ConsumerName = _readerOptions.ReaderName ?? subscription,

--- a/src/DotPulsar/Internal/ReaderBuilder.cs
+++ b/src/DotPulsar/Internal/ReaderBuilder.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -26,6 +26,8 @@ public sealed class ReaderBuilder<TMessage> : IReaderBuilder<TMessage>
     private bool _readCompacted;
     private MessageId? _startMessageId;
     private string? _topic;
+    private string? _subscriptionNamePrefix;
+
     private IHandleStateChanged<ReaderStateChanged>? _stateChangedHandler;
 
     public ReaderBuilder(IPulsarClient pulsarClient, ISchema<TMessage> schema)
@@ -72,6 +74,12 @@ public sealed class ReaderBuilder<TMessage> : IReaderBuilder<TMessage>
         return this;
     }
 
+    public IReaderBuilder<TMessage> SubscriptionNamePrefix(string subscriptionNamePrefix)
+    {
+        _subscriptionNamePrefix = subscriptionNamePrefix;
+        return this;
+    }
+
     public IReader<TMessage> Create()
     {
         if (_startMessageId is null)
@@ -85,7 +93,8 @@ public sealed class ReaderBuilder<TMessage> : IReaderBuilder<TMessage>
             MessagePrefetchCount = _messagePrefetchCount,
             ReadCompacted = _readCompacted,
             ReaderName = _readerName,
-            StateChangedHandler = _stateChangedHandler
+            StateChangedHandler = _stateChangedHandler,
+            SubscriptionNamePrefix = _subscriptionNamePrefix ?? string.Empty
         };
 
         return _pulsarClient.CreateReader(options);

--- a/src/DotPulsar/ReaderOptions.cs
+++ b/src/DotPulsar/ReaderOptions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -77,4 +77,10 @@ public sealed class ReaderOptions<TMessage>
     /// Set the topic for this reader. This is required.
     /// </summary>
     public string Topic { get; set; }
+
+    /// <summary>
+    /// The prefix for the subscription being created behind the scenes for the reader. This is optional
+    /// It can be necessary to set this if the policy for access is set to SubscriptionPrefix.
+    /// </summary>
+    public string SubscriptionNamePrefix { get; set; } = string.Empty;
 }


### PR DESCRIPTION
# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->
Currently the reader creation uses a hardcoded setup of: 
` var subscription = $"Reader-{correlationId:N}";`
Which creates the non durable subscription in Pulsar with that name for the reader instance.

However Pulsar offers a authz part where the subscription name matters due to the prefix of the subscription name being used to give access to the topic.

With that authz setting enabled and a non durable subscription that doesn't contain a prefix Wil result Pulsar giving this exception:
`AuthorizationException: org.apache.pulsar.broker.PulsarServerException: Failed to create consumer - The subscription name needs to be prefixed by the authentication role, like 674cea0f-ea2a-4358-804e-66d5fc732169-xxxx `

So this change enables configurating of a prefix for the subscription that's created under the hood. 

# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
No it has been a blocker using the reader options within our enterprise for forever AFAIk.

# Testing
I havent created any test (yet) 
Since the IReader interface only exposes a topic its hard to assert that the subscription ends up with the prefix.

Would suggest to add a `NonDurableSubscriptionName` string property to the reader interface. 
And assign the value of the subscription to  that property during creation. 

Let me know what you think.
<!-- What kind of testing has been done with the fix. -->