### PR TITLE
Add launch configurations for different workers i examples

### DIFF
--- a/samples/Consuming/Program.cs
+++ b/samples/Consuming/Program.cs
@@ -15,10 +15,19 @@
 using Consuming;
 using Extensions;
 
-await Host
-    .CreateApplicationBuilder(args)
-    //.AddHostedService<ReceiveWorker>()  // Using 'Receive'
-    //.AddHostedService<MessagesWorker>() // Using 'Messages'
-    .AddHostedService<ProcessWorker>()  // Using 'Process' (recommended)
-    .Build()
-    .RunAsync();
+var builder = Host.CreateApplicationBuilder(args);
+
+switch (args)
+{
+    case ["ReceiveWorker"]:
+        builder.AddHostedService<ReceiveWorker>();  // Using 'Receive'
+        break;
+    case ["MessagesWorker"]:
+        builder.AddHostedService<MessagesWorker>(); // Using 'Messages'
+        break;
+    default:
+        builder.AddHostedService<ProcessWorker>();  // Using 'Process' (recommended)
+        break;
+}
+
+await builder.Build().RunAsync();

--- a/samples/Consuming/Properties/launchSettings.json
+++ b/samples/Consuming/Properties/launchSettings.json
@@ -1,6 +1,22 @@
 ﻿{
   "profiles": {
-    "Processing": {
+    "MessagesWorker": {
+      "commandName": "Project",
+      "commandLineArgs": "MessagesWorker",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    },
+    "ReceiveWorker": {
+      "commandName": "Project",
+      "commandLineArgs": "ReceiveWorker",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    },
+    "ProcessWorker": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "environmentVariables": {

--- a/samples/Producing/Program.cs
+++ b/samples/Producing/Program.cs
@@ -15,9 +15,16 @@
 using Extensions;
 using Producing;
 
-await Host
-    .CreateApplicationBuilder(args)
-    //.AddHostedService<SendChannelWorker>()
-    .AddHostedService<SendWorker>()
-    .Build()
-    .RunAsync();
+var builder = Host.CreateApplicationBuilder(args);
+
+switch (args)
+{
+    case ["SendChannelWorker"]:
+        builder.AddHostedService<SendChannelWorker>();
+        break;
+    default:
+        builder.AddHostedService<SendWorker>();
+        break;
+}
+
+await builder.Build().RunAsync();

--- a/samples/Producing/Properties/launchSettings.json
+++ b/samples/Producing/Properties/launchSettings.json
@@ -1,6 +1,14 @@
 ﻿{
   "profiles": {
-    "Processing": {
+    "SendChannelWorker": {
+      "commandName": "Project",
+      "commandLineArgs": "SendChannelWorker",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    },
+    "SendWorker": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "environmentVariables": {

--- a/samples/Producing/SendChannelWorker.cs
+++ b/samples/Producing/SendChannelWorker.cs
@@ -39,7 +39,7 @@ public class SendChannelWorker : BackgroundService
 
         var delay = TimeSpan.FromSeconds(5);
 
-        _logger.LogInformation($"Will start sending messages every {delay.TotalSeconds} seconds");
+        _logger.LogInformation($"Will start sending messages every {delay.TotalSeconds} seconds with 'SendChannel'");
 
         while (!stoppingToken.IsCancellationRequested)
         {

--- a/samples/Producing/SendWorker.cs
+++ b/samples/Producing/SendWorker.cs
@@ -37,7 +37,7 @@ public sealed class SendWorker : BackgroundService
 
         var delay = TimeSpan.FromSeconds(5);
 
-        _logger.LogInformation($"Will start sending messages every {delay.TotalSeconds} seconds");
+        _logger.LogInformation($"Will start sending messages every {delay.TotalSeconds} seconds with 'Send'");
 
         while (!stoppingToken.IsCancellationRequested)
         {


### PR DESCRIPTION
Fixes Running different workers in new examples require code change and rebuild

# Description

Make the Worker configurable in the Producing and Consuming samples and add launchSettings for each worker
