### PR TITLE
feat: add support to NegativeAcknowledge in Consumer

### DIFF
--- a/src/DotPulsar/Abstractions/IConsumer.cs
+++ b/src/DotPulsar/Abstractions/IConsumer.cs
@@ -68,4 +68,19 @@ public interface IConsumer : IGetLastMessageIds, ISeek, IStateHolder<ConsumerSta
     /// Redeliver all pending messages that were pushed to this consumer that are not yet acknowledged.
     /// </summary>
     ValueTask RedeliverUnacknowledgedMessages(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Acknowledge the consumption of a single message using the MessageId.
+    /// </summary>
+    /// <summary>
+    /// Negative acknowledge the consumption of a single message using the MessageId.
+    /// This will tell the broker the message was not processed successfully and should be redelivered later.
+    /// </summary>
+    ValueTask NegativeAcknowledge(MessageId messageId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Negative acknowledge the consumption of multiple messages using the MessageIds.
+    /// This will tell the broker the messages were not processed successfully and should be redelivered later.
+    /// </summary>
+    ValueTask NegativeAcknowledge(IEnumerable<MessageId> messageIds, CancellationToken cancellationToken = default);
 }

--- a/src/DotPulsar/Extensions/ConsumerExtensions.cs
+++ b/src/DotPulsar/Extensions/ConsumerExtensions.cs
@@ -115,4 +115,11 @@ public static class ConsumerExtensions
         var currentState = await consumer.State.OnStateChangeFrom(state, delay, cancellationToken).ConfigureAwait(false);
         return new ConsumerStateChanged(consumer, currentState);
     }
+
+    /// <summary>
+    /// Negative acknowledge the consumption of a single message.
+    /// This will tell the broker the message was not processed successfully and should be redelivered later.
+    /// </summary>
+    public static async ValueTask NegativeAcknowledge(this IConsumer consumer, IMessage message, CancellationToken cancellationToken = default)
+        => await consumer.NegativeAcknowledge(message.MessageId, cancellationToken).ConfigureAwait(false);
 }

--- a/src/DotPulsar/Internal/SubConsumer.cs
+++ b/src/DotPulsar/Internal/SubConsumer.cs
@@ -237,4 +237,18 @@ public sealed class SubConsumer<TMessage> : IConsumer<TMessage>, IContainsChanne
 
     public ValueTask<IEnumerable<MessageId>> GetLastMessageIds(CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
+
+    public async ValueTask NegativeAcknowledge(MessageId messageId, CancellationToken cancellationToken)
+    {
+        var command = new CommandRedeliverUnacknowledgedMessages();
+        command.MessageIds.Add(messageId.ToMessageIdData());
+        await _executor.Execute(() => InternalRedeliverUnacknowledgedMessages(command, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask NegativeAcknowledge(IEnumerable<MessageId> messageIds, CancellationToken cancellationToken = default)
+    {
+        var command = new CommandRedeliverUnacknowledgedMessages();
+        command.MessageIds.AddRange(messageIds.Select(messageId => messageId.ToMessageIdData()));
+        await _executor.Execute(() => InternalRedeliverUnacknowledgedMessages(command, cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
Issue: [Support - Consumer.NegativeAcknowledge](https://github.com/apache/pulsar-dotpulsar/issues/45)
Issue: [Feature- Consumer.NegativeAcknowledge](https://github.com/apache/pulsar-dotpulsar/issues/234)

This pull request introduces support for negative acknowledgment of messages in the `DotPulsar` library. The changes add functionality to allow consumers to notify the broker when messages are not processed successfully, enabling their redelivery. Below are the key changes grouped by theme:

### Interface and Extension Updates

* Added `NegativeAcknowledge` methods to the `IConsumer` interface for single and multiple `MessageId` objects, allowing users to signal message redelivery.
* Introduced an extension method in `ConsumerExtensions` to simplify negative acknowledgment for `IMessage` objects.

### Internal Implementation

* Implemented `NegativeAcknowledge` methods in the `Consumer` class to handle single and multiple message acknowledgments, including logic for handling grouped sub-consumers.
* Added `NegativeAcknowledge` methods in the `SubConsumer` class to execute redelivery commands for unacknowledged messages using the broker's protocol.