### PR TITLE
Add support for AllowOutOfOrderDelivery on key_shared subscriptions

### DIFF
--- a/src/DotPulsar/Abstractions/IConsumerBuilder.cs
+++ b/src/DotPulsar/Abstractions/IConsumerBuilder.cs
@@ -92,6 +92,11 @@ public interface IConsumerBuilder<TMessage>
     IConsumerBuilder<TMessage> TopicsPattern(Regex topicsPattern);
 
     /// <summary>
+    /// Whether to allow out-of-order delivery on key_shared subscriptions. The default is 'false'.
+    /// </summary>
+    IConsumerBuilder<TMessage> AllowOutOfOrderDeliver(bool allowOutOfOrderDeliver);
+
+    /// <summary>
     /// Create the consumer.
     /// </summary>
     IConsumer<TMessage> Create();

--- a/src/DotPulsar/ConsumerOptions.cs
+++ b/src/DotPulsar/ConsumerOptions.cs
@@ -184,4 +184,12 @@ public sealed class ConsumerOptions<TMessage>
     /// Specify a pattern for topics that this consumer subscribes to. This, or setting a single topic or multiple topics, is required.
     /// </summary>
     public Regex? TopicsPattern { get; set; }
+
+    /// <summary>
+    /// Allow out-of-order delivery on key_shared subscriptions. The default is 'false'.
+    /// </summary>
+    /// <remarks>
+    /// https://pulsar.apache.org/docs/3.3.x/concepts-messaging/#preserving-order-of-processing
+    /// </remarks>
+    public bool AllowOutOfOrderDeliver { get; set; }
 }

--- a/src/DotPulsar/Internal/Consumer.cs
+++ b/src/DotPulsar/Internal/Consumer.cs
@@ -450,6 +450,14 @@ public sealed class Consumer<TMessage> : IConsumer<TMessage>
             subscribe.SubscriptionProperties.Add(keyValue);
         }
 
+        if (_consumerOptions is { SubscriptionType: SubscriptionType.KeyShared, AllowOutOfOrderDeliver: true })
+        {
+            subscribe.keySharedMeta = new KeySharedMeta
+            {
+                allowOutOfOrderDelivery = true
+            };
+        }
+
         var messagePrefetchCount = _consumerOptions.MessagePrefetchCount;
         var messageFactory = new MessageFactory<TMessage>(_consumerOptions.Schema);
         var batchHandler = new BatchHandler<TMessage>(true, messageFactory);

--- a/src/DotPulsar/Internal/ConsumerBuilder.cs
+++ b/src/DotPulsar/Internal/ConsumerBuilder.cs
@@ -36,6 +36,7 @@ public sealed class ConsumerBuilder<TMessage> : IConsumerBuilder<TMessage>
     private readonly HashSet<string> _topics;
     private Regex? _topicsPattern;
     private IHandleStateChanged<ConsumerStateChanged>? _stateChangedHandler;
+    private bool _allowOutOfOrderDeliver;
 
     public ConsumerBuilder(IPulsarClient pulsarClient, ISchema<TMessage> schema)
     {
@@ -143,6 +144,12 @@ public sealed class ConsumerBuilder<TMessage> : IConsumerBuilder<TMessage>
         return this;
     }
 
+    public IConsumerBuilder<TMessage> AllowOutOfOrderDeliver(bool allowOutOfOrderDeliver)
+    {
+        _allowOutOfOrderDeliver = allowOutOfOrderDeliver;
+        return this;
+    }
+
     public IConsumer<TMessage> Create()
     {
         if (string.IsNullOrEmpty(_subscriptionName))
@@ -164,7 +171,8 @@ public sealed class ConsumerBuilder<TMessage> : IConsumerBuilder<TMessage>
             SubscriptionProperties = _subscriptionProperties,
             SubscriptionType = _subscriptionType,
             Topics = _topics,
-            TopicsPattern = _topicsPattern
+            TopicsPattern = _topicsPattern,
+            AllowOutOfOrderDeliver = _allowOutOfOrderDeliver
         };
 
         return _pulsarClient.CreateConsumer(options);


### PR DESCRIPTION
# Description

Adds support for setting `allowOutOfOrderDelivery` on `Key_Shared` subscription types

https://pulsar.apache.org/docs/3.3.x/concepts-messaging/#preserving-order-of-processing

# Regression

No

# Testing

Manual verification that the flag is set correctly