### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,8 +20,8 @@
 github:
   description: "The official .NET client library for Apache Pulsar"
   homepage: https://pulsar.apache.org/
-  ghp_branch:  gh-pages
-  ghp_path:    docs/api/_site
+  ghp_branch: gh-pages
+  ghp_path: docs/api/_site
   labels:
     - pulsar
     - pubsub
@@ -39,14 +39,27 @@ github:
     projects: true
   enabled_merge_buttons:
     # enable squash button:
-    squash:  true
+    squash: true
     # disable merge button:
-    merge:   false
+    merge: false
     # disable rebase button:
-    rebase:  false
+    rebase: false
 
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  commits:      commits@pulsar.apache.org
-  issues:       commits@pulsar.apache.org
+  commits: commits@pulsar.apache.org
+  issues: commits@pulsar.apache.org
   pullrequests: commits@pulsar.apache.org
-  discussions:  dev@pulsar.apache.org
+  discussions: dev@pulsar.apache.org


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
