### PR TITLE
Update tracing header constants to follow standard naming conventions

### DIFF
--- a/src/DotPulsar/Internal/Constants.cs
+++ b/src/DotPulsar/Internal/Constants.cs
@@ -40,8 +40,8 @@ public static class Constants
         MetadataSizeOffset = 6;
         MetadataOffset = 10;
         ConversationId = "messaging.conversation_id";
-        TraceParent = "messaging.trace_parent";
-        TraceState = "messaging.trace_state";
+        TraceParent = "traceparent";
+        TraceState = "tracestate";
         TimestampToTicks = TimeSpan.TicksPerSecond / (double) Stopwatch.Frequency;
     }
 


### PR DESCRIPTION
Fixes #249

Update tracing header constants to match standard naming conventions

https://www.w3.org/TR/trace-context/#trace-context-http-headers-format